### PR TITLE
feat: token 成本看板 / Token Cost Dashboard

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -2883,16 +2883,22 @@ window.__ModuleLoader__.load({
       var layerState = react.useState("");
       var layer = layerState[0];
       var setLayer = layerState[1];
+      var rangeState = react.useState(0);
+      var rangeDays = rangeState[0];
+      var setRangeDays = rangeState[1];
+      var rangeOpenState = react.useState(false);
+      var rangeOpen = rangeOpenState[0];
+      var setRangeOpen = rangeOpenState[1];
 
       var load = react.useCallback(function () {
         setError(null);
-        rpc("dsh-memory/token-cost", { granularity: granularity })
+        rpc("dsh-memory/token-cost", { granularity: granularity, rangeDays: rangeDays })
           .then(function (r) {
             if (r && r.ok) setData(r.value);
             else setError(r && r.error ? r.error.message : "RPC error");
           })
           .catch(function (e) { setError(String((e && e.message) || e)); });
-      }, [rpc, granularity]);
+      }, [rpc, granularity, rangeDays]);
 
       react.useEffect(function () {
         load();
@@ -2901,6 +2907,7 @@ window.__ModuleLoader__.load({
       }, [load]);
 
       var fmtInt = function (n) { return String(Math.round(n)).replace(/\B(?=(\d{3})+(?!\d))/g, ","); };
+      var fmtModel = function (p, m) { return p ? p + "/" + m : m; };
       var fmtDate = function (ts) {
         try {
           var d = new Date(ts);
@@ -2976,9 +2983,27 @@ window.__ModuleLoader__.load({
           "div", { style: Object.assign({}, S.flexRow, { marginBottom: 10 }) },
           react.createElement(Segmented, { value: layer, options: LAYER_OPTS, onChange: setLayer }),
           react.createElement(Segmented, { value: granularity, options: GRAN_OPTS, onChange: setGranularity }),
+          react.createElement(NButton, { onClick: function () { setRangeOpen(!rangeOpen); } }, rangeDays > 0 ? "近 " + rangeDays + " 天" : "近N天"),
           react.createElement("div", { style: S.grow }),
           react.createElement(NButton, { onClick: load }, "刷新"),
         ),
+        rangeOpen
+          ? react.createElement(
+              "div", { style: Object.assign({}, S.flexRow, { marginBottom: 10 }) },
+              react.createElement("span", { style: S.muted }, "展示近 N 天（1~365 整数，清空=默认窗口）"),
+              react.createElement(NInput, {
+                value: rangeDays === 0 ? "" : String(rangeDays),
+                placeholder: "如 30",
+                style: { width: 90 },
+                onChange: function (e) {
+                  var v = String(e.target.value || "").trim();
+                  if (v === "") { setRangeDays(0); return; }
+                  var n = Number(v);
+                  if (Number.isInteger(n) && n > 0 && n <= 365) setRangeDays(n);
+                },
+              }),
+            )
+          : null,
         error
           ? react.createElement("div", { style: S.error }, "成本读取失败：" + error)
           : null,
@@ -2998,7 +3023,7 @@ window.__ModuleLoader__.load({
                 }),
               ),
             )
-          : react.createElement("p", { style: S.muted }, data ? "当前层级暂无趋势数据。" : "加载中…"),
+          : react.createElement("p", { style: S.muted }, data ? "暂无成本数据（触发一次蒸馏后这里会出现趋势）。" : "加载中…"),
         react.createElement("div", { style: S.panelLabel }, "层级成本（输出 token）"),
         react.createElement(
           "table", { style: { width: "100%", borderCollapse: "collapse", marginBottom: 14 } },
@@ -3097,9 +3122,10 @@ window.__ModuleLoader__.load({
               "div", null,
               react.createElement("div", { style: S.panelLabel }, "按模型（累计）"),
               byModel.map(function (m) {
+                var label = fmtModel(m.provider, m.model);
                 return react.createElement(
-                  "div", { key: "m-" + m.model, style: S.infoRow },
-                  react.createElement("span", { style: S.infoKey }, m.model),
+                  "div", { key: "m-" + label, style: S.infoRow },
+                  react.createElement("span", { style: S.infoKey }, label),
                   react.createElement("span", { style: S.infoVal }, m.calls + " 次 · 输出 " + fmtInt(m.outputTokens) + " · 思考 " + fmtInt(m.reasoningTokens)),
                 );
               }),

--- a/client/client.js
+++ b/client/client.js
@@ -2911,7 +2911,9 @@ window.__ModuleLoader__.load({
       var fmtDate = function (ts) {
         try {
           var d = new Date(ts);
-          if (granularity === "month") return (d.getMonth() + 1) + "月";
+          // 近 N 天时后端强制日粒度，用 trend 实际粒度（而非用户选的周/月）格式化横轴
+          var g = data && data.trend ? data.trend.granularity : granularity;
+          if (g === "month") return (d.getMonth() + 1) + "月";
           return (d.getMonth() + 1) + "/" + d.getDate();
         } catch (e) { return ""; }
       };

--- a/client/client.js
+++ b/client/client.js
@@ -2824,12 +2824,283 @@ window.__ModuleLoader__.load({
       );
     }
 
+    // ── 折线图 helper：把桶序列画成 SVG 多模型折线 ──
+    function renderCostChart(buckets, models, maxY, fmtDate, fmtInt, palette) {
+      var W = 600, H = 200, L = 46, R = 10, T = 10, B = 26;
+      var iw = W - L - R;
+      var ih = H - T - B;
+      var n = buckets.length;
+      var x = function (i) { return L + (n <= 1 ? iw / 2 : (i / (n - 1)) * iw); };
+      var y = function (v) { return T + ih - (v / maxY) * ih; };
+      var yTicks = [0, maxY / 2, maxY];
+      var xIdx = n > 2 ? [0, Math.floor((n - 1) / 2), n - 1] : n === 2 ? [0, 1] : [0];
+      return react.createElement(
+        "svg",
+        { viewBox: "0 0 " + W + " " + H, style: { width: "100%", height: "auto", display: "block" } },
+        react.createElement("line", { x1: L, y1: y(0), x2: W - R, y2: y(0), stroke: "var(--dsh-mem-border)", strokeWidth: 1 }),
+        yTicks.map(function (v) {
+          return react.createElement("text", { key: "yt" + v, x: L - 6, y: y(v) + 4, textAnchor: "end", fontSize: 10, fill: "var(--dsh-mem-text-3)" }, fmtInt(v));
+        }),
+        xIdx.map(function (i) {
+          return react.createElement("text", { key: "xt" + i, x: x(i), y: H - 8, textAnchor: "middle", fontSize: 10, fill: "var(--dsh-mem-text-3)" }, fmtDate(buckets[i] ? buckets[i].ts : 0));
+        }),
+        models.map(function (m, mi) {
+          var pts = buckets.map(function (b, i) { return x(i) + "," + y(b.byModel[m] || 0); }).join(" ");
+          return react.createElement("polyline", { key: "pl" + m, points: pts, fill: "none", stroke: palette[mi % palette.length], strokeWidth: 2, strokeLinejoin: "round", strokeLinecap: "round" });
+        }),
+      );
+    }
+
+    // ── Tab：蒸馏成本看板（折线图 + 层级×窗口表格 + 总览） ──
+    function CostTab(props) {
+      var rpc = props.rpc;
+      var dataState = react.useState(null);
+      var data = dataState[0];
+      var setData = dataState[1];
+      var errState = react.useState(null);
+      var error = errState[0];
+      var setError = errState[1];
+      var granState = react.useState("day");
+      var granularity = granState[0];
+      var setGranularity = granState[1];
+      var layerState = react.useState("");
+      var layer = layerState[0];
+      var setLayer = layerState[1];
+
+      var load = react.useCallback(function () {
+        setError(null);
+        rpc("dsh-memory/token-cost", { granularity: granularity })
+          .then(function (r) {
+            if (r && r.ok) setData(r.value);
+            else setError(r && r.error ? r.error.message : "RPC error");
+          })
+          .catch(function (e) { setError(String((e && e.message) || e)); });
+      }, [rpc, granularity]);
+
+      react.useEffect(function () {
+        load();
+        var timer = setInterval(load, 5000);
+        return function () { clearInterval(timer); };
+      }, [load]);
+
+      var fmtInt = function (n) { return String(Math.round(n)).replace(/\B(?=(\d{3})+(?!\d))/g, ","); };
+      var fmtDate = function (ts) {
+        try {
+          var d = new Date(ts);
+          if (granularity === "month") return (d.getMonth() + 1) + "月";
+          return (d.getMonth() + 1) + "/" + d.getDate();
+        } catch (e) { return ""; }
+      };
+      var RANGE_LABELS = { day: "今日", week: "本周", month: "本月", all: "累计" };
+      var LAYER_OPTS = [{ key: "", label: "全部" }, { key: "l1", label: "L1" }, { key: "l2", label: "L2" }, { key: "l3", label: "L3" }];
+      var GRAN_OPTS = [{ key: "day", label: "日" }, { key: "week", label: "周" }, { key: "month", label: "月" }];
+      var PALETTE = ["#4f8cff", "#ff7a45", "#34c98e", "#b26bff", "#ffc53d", "#ff5c8a", "#22c1c3", "#8c97a8"];
+
+      var windows = (data && data.windows) || [];
+      var byModel = (data && data.byModel) || [];
+      var byLayer = (data && data.byLayer) || [];
+      var trend = data && data.trend ? data.trend : null;
+
+      // 趋势桶（按 layer 过滤/合并；全部 = l1+l2+l3 逐桶相加）
+      var buckets = [];
+      if (trend && trend.byLayer) {
+        if (layer === "l1" || layer === "l2" || layer === "l3") {
+          buckets = trend.byLayer[layer] || [];
+        } else {
+          var seqs = [trend.byLayer.l1 || [], trend.byLayer.l2 || [], trend.byLayer.l3 || []];
+          var n = seqs[0].length;
+          for (var i = 0; i < n; i++) {
+            var merged = { ts: 0, total: 0, byModel: {} };
+            for (var s = 0; s < seqs.length; s++) {
+              var seq = seqs[s];
+              if (seq && seq[i]) {
+                if (merged.ts === 0) merged.ts = seq[i].ts;
+                merged.total += seq[i].total;
+                Object.keys(seq[i].byModel).forEach(function (m) {
+                  merged.byModel[m] = (merged.byModel[m] || 0) + seq[i].byModel[m];
+                });
+              }
+            }
+            buckets.push(merged);
+          }
+        }
+      }
+
+      // 折线模型 + maxY
+      var models = [];
+      var seen = {};
+      buckets.forEach(function (b) {
+        Object.keys(b.byModel).forEach(function (m) {
+          if (!seen[m]) { seen[m] = true; models.push(m); }
+        });
+      });
+      models.sort();
+      var maxY = 1;
+      buckets.forEach(function (b) {
+        if (b.total > maxY) maxY = b.total;
+        models.forEach(function (m) { if ((b.byModel[m] || 0) > maxY) maxY = b.byModel[m]; });
+      });
+
+      // 层级×窗口表格数据（layer → {range: 格子}）
+      var layerTable = byLayer.map(function (lc) {
+        var win = {};
+        lc.windows.forEach(function (w) { win[w.range] = w; });
+        return { layer: lc.layer, win: win };
+      });
+
+      var thFirst = { fontSize: 12, fontWeight: 600, color: "var(--dsh-mem-text-3)", textAlign: "left", padding: "4px 10px", borderBottom: "1px solid var(--dsh-mem-border)" };
+      var thStyle = { fontSize: 12, fontWeight: 600, color: "var(--dsh-mem-text-3)", textAlign: "right", padding: "4px 10px", borderBottom: "1px solid var(--dsh-mem-border)" };
+      var tdFirst = { fontSize: 12.5, fontWeight: 600, color: "var(--dsh-mem-text-1)", textAlign: "left", padding: "4px 10px" };
+      var tdStyle = { fontSize: 12.5, color: "var(--dsh-mem-text-1)", textAlign: "right", padding: "4px 10px", fontFamily: "ui-monospace, Consolas, monospace" };
+
+      return react.createElement(
+        "div", null,
+        react.createElement(
+          "div", { style: Object.assign({}, S.flexRow, { marginBottom: 10 }) },
+          react.createElement(Segmented, { value: layer, options: LAYER_OPTS, onChange: setLayer }),
+          react.createElement(Segmented, { value: granularity, options: GRAN_OPTS, onChange: setGranularity }),
+          react.createElement("div", { style: S.grow }),
+          react.createElement(NButton, { onClick: load }, "刷新"),
+        ),
+        error
+          ? react.createElement("div", { style: S.error }, "成本读取失败：" + error)
+          : null,
+        react.createElement("div", { style: S.panelLabel }, "成本趋势（按模型）"),
+        buckets.length > 0
+          ? react.createElement(
+              "div", null,
+              renderCostChart(buckets, models, maxY, fmtDate, fmtInt, PALETTE),
+              react.createElement(
+                "div", { style: { display: "flex", flexWrap: "wrap", gap: "4px 12px", margin: "6px 0 14px" } },
+                models.map(function (m, mi) {
+                  return react.createElement(
+                    "span", { key: "lg" + m, style: { display: "inline-flex", alignItems: "center", gap: 4, fontSize: 12, color: "var(--dsh-mem-text-2)" } },
+                    react.createElement("span", { style: { width: 10, height: 10, borderRadius: 2, background: PALETTE[mi % PALETTE.length], display: "inline-block" } }),
+                    m,
+                  );
+                }),
+              ),
+            )
+          : react.createElement("p", { style: S.muted }, data ? "当前层级暂无趋势数据。" : "加载中…"),
+        react.createElement("div", { style: S.panelLabel }, "层级成本（输出 token）"),
+        react.createElement(
+          "table", { style: { width: "100%", borderCollapse: "collapse", marginBottom: 14 } },
+          react.createElement(
+            "thead", null,
+            react.createElement(
+              "tr", null,
+              react.createElement("th", { style: thFirst }, "层级"),
+              ["day", "week", "month", "all"].map(function (r) {
+                return react.createElement("th", { key: r, style: thStyle }, RANGE_LABELS[r]);
+              }),
+            ),
+          ),
+          react.createElement(
+            "tbody", null,
+            layerTable.map(function (lc) {
+              return react.createElement(
+                "tr", { key: lc.layer },
+                react.createElement("td", { style: tdFirst }, lc.layer.toUpperCase()),
+                ["day", "week", "month", "all"].map(function (r) {
+                  var w = lc.win[r];
+                  return react.createElement("td", { key: r, style: tdStyle }, w ? fmtInt(w.outputTokens) : "0");
+                }),
+              );
+            }),
+          ),
+        ),
+        react.createElement("div", { style: S.panelLabel }, "层级成本（单次 avg）"),
+        react.createElement(
+          "table", { style: { width: "100%", borderCollapse: "collapse", marginBottom: 14 } },
+          react.createElement(
+            "thead", null,
+            react.createElement(
+              "tr", null,
+              react.createElement("th", { style: thFirst }, "层级"),
+              ["day", "week", "month", "all"].map(function (r) {
+                return react.createElement("th", { key: r, style: thStyle }, RANGE_LABELS[r] + "-avg");
+              }),
+            ),
+          ),
+          react.createElement(
+            "tbody", null,
+            layerTable.map(function (lc) {
+              return react.createElement(
+                "tr", { key: lc.layer },
+                react.createElement("td", { style: tdFirst }, lc.layer.toUpperCase()),
+                ["day", "week", "month", "all"].map(function (r) {
+                  var w = lc.win[r];
+                  return react.createElement("td", { key: r, style: tdStyle }, w ? fmtInt(w.avgOutputTokens) : "0");
+                }),
+              );
+            }),
+          ),
+        ),
+        react.createElement("div", { style: S.panelLabel }, "层级成本（单次 median）"),
+        react.createElement(
+          "table", { style: { width: "100%", borderCollapse: "collapse", marginBottom: 14 } },
+          react.createElement(
+            "thead", null,
+            react.createElement(
+              "tr", null,
+              react.createElement("th", { style: thFirst }, "层级"),
+              ["day", "week", "month", "all"].map(function (r) {
+                return react.createElement("th", { key: r, style: thStyle }, RANGE_LABELS[r] + "-median");
+              }),
+            ),
+          ),
+          react.createElement(
+            "tbody", null,
+            layerTable.map(function (lc) {
+              return react.createElement(
+                "tr", { key: lc.layer },
+                react.createElement("td", { style: tdFirst }, lc.layer.toUpperCase()),
+                ["day", "week", "month", "all"].map(function (r) {
+                  var w = lc.win[r];
+                  return react.createElement("td", { key: r, style: tdStyle }, w ? fmtInt(w.medianOutputTokens) : "0");
+                }),
+              );
+            }),
+          ),
+        ),
+        react.createElement("div", { style: S.panelLabel }, "时间窗口总览"),
+        react.createElement(
+          "div", { style: S.statGrid },
+          windows.map(function (w) {
+            return react.createElement(
+              "div", { key: w.range, className: "dsh-mem-card", style: S.statTile },
+              react.createElement("div", { style: S.statNum }, fmtInt(w.outputTokens + w.reasoningTokens)),
+              react.createElement("div", { style: S.statLabel }, RANGE_LABELS[w.range] + " · 总输出 token"),
+              react.createElement("div", { style: S.muted }, "文字 " + fmtInt(w.outputTokens) + " · 思考 " + fmtInt(w.reasoningTokens) + " · " + w.calls + " 次调用"),
+            );
+          }),
+        ),
+        byModel.length > 0
+          ? react.createElement(
+              "div", null,
+              react.createElement("div", { style: S.panelLabel }, "按模型（累计）"),
+              byModel.map(function (m) {
+                return react.createElement(
+                  "div", { key: "m-" + m.model, style: S.infoRow },
+                  react.createElement("span", { style: S.infoKey }, m.model),
+                  react.createElement("span", { style: S.infoVal }, m.calls + " 次 · 输出 " + fmtInt(m.outputTokens) + " · 思考 " + fmtInt(m.reasoningTokens)),
+                );
+              }),
+            )
+          : null,
+        data
+          ? react.createElement("p", { style: S.hint }, "输入按字符、输出/思考按 token 计；趋势图 Y 轴为输出 token，上方可切换层级与颗粒度。" )
+          : null,
+      );
+    }
+
     // ── 主面板：Tab 框架 ──
     var TABS = [
       ["overview", "概览"],
       ["records", "记忆"],
       ["scenes", "场景"],
       ["persona", "画像"],
+      ["cost", "成本"],
       ["log", "日志"],
     ];
 
@@ -2898,6 +3169,7 @@ window.__ModuleLoader__.load({
       else if (tab === "records") body = react.createElement(RecordsTab, { rpc: rpc });
       else if (tab === "scenes") body = react.createElement(ScenesTab, { rpc: rpc });
       else if (tab === "persona") body = react.createElement(PersonaTab, { rpc: rpc });
+      else if (tab === "cost") body = react.createElement(CostTab, { rpc: rpc });
       else body = react.createElement(LogTab, { rpc: rpc });
 
       return react.createElement(

--- a/client/client.js
+++ b/client/client.js
@@ -877,6 +877,15 @@ window.__ModuleLoader__.load({
         "  --dsh-mem-text-2: var(--dsw-alias-label-secondary, #61666b);",
         "  --dsh-mem-text-3: var(--dsw-alias-label-tertiary, #6e7781);",
         "  --dsh-mem-danger: var(--dsw-alias-state-error-primary, #d0403f);",
+        // 图表系列（成本折线图）：8 档固定色，PALETTE 只引用 var()；1 档锚品牌蓝，8 档中性"其他"
+        "  --dsh-mem-chart-1: #4d6bfe;",
+        "  --dsh-mem-chart-2: #0e9c8f;",
+        "  --dsh-mem-chart-3: #1f9d55;",
+        "  --dsh-mem-chart-4: #a8821c;",
+        "  --dsh-mem-chart-5: #d97a0d;",
+        "  --dsh-mem-chart-6: #d64570;",
+        "  --dsh-mem-chart-7: #7c5cff;",
+        "  --dsh-mem-chart-8: #61666b;",
         // 档位色 = 灰 → 品牌蓝 的渐变阶（chat/work 过渡蓝 / auto 品牌蓝）；
         // 文字对比度按 pill 真实底色（流光内底 = bg-card 97% + 档位色 3%）复算 AA 达标
         "  --dsh-mem-mode-chat: #5a69b0;",
@@ -908,6 +917,14 @@ window.__ModuleLoader__.load({
         "  --dsh-mem-text-2: var(--dsw-alias-label-secondary, #cfd3d6);",
         "  --dsh-mem-text-3: var(--dsw-alias-label-tertiary, #8892a6);",
         "  --dsh-mem-danger: var(--dsw-alias-state-error-primary, #f4707b);",
+        "  --dsh-mem-chart-1: #6e85ff;",
+        "  --dsh-mem-chart-2: #35c4b5;",
+        "  --dsh-mem-chart-3: #52c98d;",
+        "  --dsh-mem-chart-4: #d9b23e;",
+        "  --dsh-mem-chart-5: #f59e5b;",
+        "  --dsh-mem-chart-6: #f47ba2;",
+        "  --dsh-mem-chart-7: #a78bfa;",
+        "  --dsh-mem-chart-8: #8892a6;",
         "  --dsh-mem-mode-chat: #97a4ff;",
         "  --dsh-mem-mode-work: #8295ff;",
         "  --dsh-mem-mode-auto: #7b90ff;",
@@ -2894,7 +2911,7 @@ window.__ModuleLoader__.load({
       var RANGE_LABELS = { day: "今日", week: "本周", month: "本月", all: "累计" };
       var LAYER_OPTS = [{ key: "", label: "全部" }, { key: "l1", label: "L1" }, { key: "l2", label: "L2" }, { key: "l3", label: "L3" }];
       var GRAN_OPTS = [{ key: "day", label: "日" }, { key: "week", label: "周" }, { key: "month", label: "月" }];
-      var PALETTE = ["#4f8cff", "#ff7a45", "#34c98e", "#b26bff", "#ffc53d", "#ff5c8a", "#22c1c3", "#8c97a8"];
+      var PALETTE = ["var(--dsh-mem-chart-1)", "var(--dsh-mem-chart-2)", "var(--dsh-mem-chart-3)", "var(--dsh-mem-chart-4)", "var(--dsh-mem-chart-5)", "var(--dsh-mem-chart-6)", "var(--dsh-mem-chart-7)", "var(--dsh-mem-chart-8)"];
 
       var windows = (data && data.windows) || [];
       var byModel = (data && data.byModel) || [];
@@ -2975,7 +2992,7 @@ window.__ModuleLoader__.load({
                 models.map(function (m, mi) {
                   return react.createElement(
                     "span", { key: "lg" + m, style: { display: "inline-flex", alignItems: "center", gap: 4, fontSize: 12, color: "var(--dsh-mem-text-2)" } },
-                    react.createElement("span", { style: { width: 10, height: 10, borderRadius: 2, background: PALETTE[mi % PALETTE.length], display: "inline-block" } }),
+                    react.createElement("span", { style: { width: 10, height: 10, borderRadius: 4, background: PALETTE[mi % PALETTE.length], display: "inline-block" } }),
                     m,
                   );
                 }),

--- a/dist/client.js
+++ b/dist/client.js
@@ -2883,16 +2883,22 @@ window.__ModuleLoader__.load({
       var layerState = react.useState("");
       var layer = layerState[0];
       var setLayer = layerState[1];
+      var rangeState = react.useState(0);
+      var rangeDays = rangeState[0];
+      var setRangeDays = rangeState[1];
+      var rangeOpenState = react.useState(false);
+      var rangeOpen = rangeOpenState[0];
+      var setRangeOpen = rangeOpenState[1];
 
       var load = react.useCallback(function () {
         setError(null);
-        rpc("dsh-memory/token-cost", { granularity: granularity })
+        rpc("dsh-memory/token-cost", { granularity: granularity, rangeDays: rangeDays })
           .then(function (r) {
             if (r && r.ok) setData(r.value);
             else setError(r && r.error ? r.error.message : "RPC error");
           })
           .catch(function (e) { setError(String((e && e.message) || e)); });
-      }, [rpc, granularity]);
+      }, [rpc, granularity, rangeDays]);
 
       react.useEffect(function () {
         load();
@@ -2901,6 +2907,7 @@ window.__ModuleLoader__.load({
       }, [load]);
 
       var fmtInt = function (n) { return String(Math.round(n)).replace(/\B(?=(\d{3})+(?!\d))/g, ","); };
+      var fmtModel = function (p, m) { return p ? p + "/" + m : m; };
       var fmtDate = function (ts) {
         try {
           var d = new Date(ts);
@@ -2976,9 +2983,27 @@ window.__ModuleLoader__.load({
           "div", { style: Object.assign({}, S.flexRow, { marginBottom: 10 }) },
           react.createElement(Segmented, { value: layer, options: LAYER_OPTS, onChange: setLayer }),
           react.createElement(Segmented, { value: granularity, options: GRAN_OPTS, onChange: setGranularity }),
+          react.createElement(NButton, { onClick: function () { setRangeOpen(!rangeOpen); } }, rangeDays > 0 ? "近 " + rangeDays + " 天" : "近N天"),
           react.createElement("div", { style: S.grow }),
           react.createElement(NButton, { onClick: load }, "刷新"),
         ),
+        rangeOpen
+          ? react.createElement(
+              "div", { style: Object.assign({}, S.flexRow, { marginBottom: 10 }) },
+              react.createElement("span", { style: S.muted }, "展示近 N 天（1~365 整数，清空=默认窗口）"),
+              react.createElement(NInput, {
+                value: rangeDays === 0 ? "" : String(rangeDays),
+                placeholder: "如 30",
+                style: { width: 90 },
+                onChange: function (e) {
+                  var v = String(e.target.value || "").trim();
+                  if (v === "") { setRangeDays(0); return; }
+                  var n = Number(v);
+                  if (Number.isInteger(n) && n > 0 && n <= 365) setRangeDays(n);
+                },
+              }),
+            )
+          : null,
         error
           ? react.createElement("div", { style: S.error }, "成本读取失败：" + error)
           : null,
@@ -2998,7 +3023,7 @@ window.__ModuleLoader__.load({
                 }),
               ),
             )
-          : react.createElement("p", { style: S.muted }, data ? "当前层级暂无趋势数据。" : "加载中…"),
+          : react.createElement("p", { style: S.muted }, data ? "暂无成本数据（触发一次蒸馏后这里会出现趋势）。" : "加载中…"),
         react.createElement("div", { style: S.panelLabel }, "层级成本（输出 token）"),
         react.createElement(
           "table", { style: { width: "100%", borderCollapse: "collapse", marginBottom: 14 } },
@@ -3097,9 +3122,10 @@ window.__ModuleLoader__.load({
               "div", null,
               react.createElement("div", { style: S.panelLabel }, "按模型（累计）"),
               byModel.map(function (m) {
+                var label = fmtModel(m.provider, m.model);
                 return react.createElement(
-                  "div", { key: "m-" + m.model, style: S.infoRow },
-                  react.createElement("span", { style: S.infoKey }, m.model),
+                  "div", { key: "m-" + label, style: S.infoRow },
+                  react.createElement("span", { style: S.infoKey }, label),
                   react.createElement("span", { style: S.infoVal }, m.calls + " 次 · 输出 " + fmtInt(m.outputTokens) + " · 思考 " + fmtInt(m.reasoningTokens)),
                 );
               }),

--- a/dist/client.js
+++ b/dist/client.js
@@ -2911,7 +2911,9 @@ window.__ModuleLoader__.load({
       var fmtDate = function (ts) {
         try {
           var d = new Date(ts);
-          if (granularity === "month") return (d.getMonth() + 1) + "月";
+          // 近 N 天时后端强制日粒度，用 trend 实际粒度（而非用户选的周/月）格式化横轴
+          var g = data && data.trend ? data.trend.granularity : granularity;
+          if (g === "month") return (d.getMonth() + 1) + "月";
           return (d.getMonth() + 1) + "/" + d.getDate();
         } catch (e) { return ""; }
       };

--- a/dist/client.js
+++ b/dist/client.js
@@ -2824,12 +2824,283 @@ window.__ModuleLoader__.load({
       );
     }
 
+    // ── 折线图 helper：把桶序列画成 SVG 多模型折线 ──
+    function renderCostChart(buckets, models, maxY, fmtDate, fmtInt, palette) {
+      var W = 600, H = 200, L = 46, R = 10, T = 10, B = 26;
+      var iw = W - L - R;
+      var ih = H - T - B;
+      var n = buckets.length;
+      var x = function (i) { return L + (n <= 1 ? iw / 2 : (i / (n - 1)) * iw); };
+      var y = function (v) { return T + ih - (v / maxY) * ih; };
+      var yTicks = [0, maxY / 2, maxY];
+      var xIdx = n > 2 ? [0, Math.floor((n - 1) / 2), n - 1] : n === 2 ? [0, 1] : [0];
+      return react.createElement(
+        "svg",
+        { viewBox: "0 0 " + W + " " + H, style: { width: "100%", height: "auto", display: "block" } },
+        react.createElement("line", { x1: L, y1: y(0), x2: W - R, y2: y(0), stroke: "var(--dsh-mem-border)", strokeWidth: 1 }),
+        yTicks.map(function (v) {
+          return react.createElement("text", { key: "yt" + v, x: L - 6, y: y(v) + 4, textAnchor: "end", fontSize: 10, fill: "var(--dsh-mem-text-3)" }, fmtInt(v));
+        }),
+        xIdx.map(function (i) {
+          return react.createElement("text", { key: "xt" + i, x: x(i), y: H - 8, textAnchor: "middle", fontSize: 10, fill: "var(--dsh-mem-text-3)" }, fmtDate(buckets[i] ? buckets[i].ts : 0));
+        }),
+        models.map(function (m, mi) {
+          var pts = buckets.map(function (b, i) { return x(i) + "," + y(b.byModel[m] || 0); }).join(" ");
+          return react.createElement("polyline", { key: "pl" + m, points: pts, fill: "none", stroke: palette[mi % palette.length], strokeWidth: 2, strokeLinejoin: "round", strokeLinecap: "round" });
+        }),
+      );
+    }
+
+    // ── Tab：蒸馏成本看板（折线图 + 层级×窗口表格 + 总览） ──
+    function CostTab(props) {
+      var rpc = props.rpc;
+      var dataState = react.useState(null);
+      var data = dataState[0];
+      var setData = dataState[1];
+      var errState = react.useState(null);
+      var error = errState[0];
+      var setError = errState[1];
+      var granState = react.useState("day");
+      var granularity = granState[0];
+      var setGranularity = granState[1];
+      var layerState = react.useState("");
+      var layer = layerState[0];
+      var setLayer = layerState[1];
+
+      var load = react.useCallback(function () {
+        setError(null);
+        rpc("dsh-memory/token-cost", { granularity: granularity })
+          .then(function (r) {
+            if (r && r.ok) setData(r.value);
+            else setError(r && r.error ? r.error.message : "RPC error");
+          })
+          .catch(function (e) { setError(String((e && e.message) || e)); });
+      }, [rpc, granularity]);
+
+      react.useEffect(function () {
+        load();
+        var timer = setInterval(load, 5000);
+        return function () { clearInterval(timer); };
+      }, [load]);
+
+      var fmtInt = function (n) { return String(Math.round(n)).replace(/\B(?=(\d{3})+(?!\d))/g, ","); };
+      var fmtDate = function (ts) {
+        try {
+          var d = new Date(ts);
+          if (granularity === "month") return (d.getMonth() + 1) + "月";
+          return (d.getMonth() + 1) + "/" + d.getDate();
+        } catch (e) { return ""; }
+      };
+      var RANGE_LABELS = { day: "今日", week: "本周", month: "本月", all: "累计" };
+      var LAYER_OPTS = [{ key: "", label: "全部" }, { key: "l1", label: "L1" }, { key: "l2", label: "L2" }, { key: "l3", label: "L3" }];
+      var GRAN_OPTS = [{ key: "day", label: "日" }, { key: "week", label: "周" }, { key: "month", label: "月" }];
+      var PALETTE = ["#4f8cff", "#ff7a45", "#34c98e", "#b26bff", "#ffc53d", "#ff5c8a", "#22c1c3", "#8c97a8"];
+
+      var windows = (data && data.windows) || [];
+      var byModel = (data && data.byModel) || [];
+      var byLayer = (data && data.byLayer) || [];
+      var trend = data && data.trend ? data.trend : null;
+
+      // 趋势桶（按 layer 过滤/合并；全部 = l1+l2+l3 逐桶相加）
+      var buckets = [];
+      if (trend && trend.byLayer) {
+        if (layer === "l1" || layer === "l2" || layer === "l3") {
+          buckets = trend.byLayer[layer] || [];
+        } else {
+          var seqs = [trend.byLayer.l1 || [], trend.byLayer.l2 || [], trend.byLayer.l3 || []];
+          var n = seqs[0].length;
+          for (var i = 0; i < n; i++) {
+            var merged = { ts: 0, total: 0, byModel: {} };
+            for (var s = 0; s < seqs.length; s++) {
+              var seq = seqs[s];
+              if (seq && seq[i]) {
+                if (merged.ts === 0) merged.ts = seq[i].ts;
+                merged.total += seq[i].total;
+                Object.keys(seq[i].byModel).forEach(function (m) {
+                  merged.byModel[m] = (merged.byModel[m] || 0) + seq[i].byModel[m];
+                });
+              }
+            }
+            buckets.push(merged);
+          }
+        }
+      }
+
+      // 折线模型 + maxY
+      var models = [];
+      var seen = {};
+      buckets.forEach(function (b) {
+        Object.keys(b.byModel).forEach(function (m) {
+          if (!seen[m]) { seen[m] = true; models.push(m); }
+        });
+      });
+      models.sort();
+      var maxY = 1;
+      buckets.forEach(function (b) {
+        if (b.total > maxY) maxY = b.total;
+        models.forEach(function (m) { if ((b.byModel[m] || 0) > maxY) maxY = b.byModel[m]; });
+      });
+
+      // 层级×窗口表格数据（layer → {range: 格子}）
+      var layerTable = byLayer.map(function (lc) {
+        var win = {};
+        lc.windows.forEach(function (w) { win[w.range] = w; });
+        return { layer: lc.layer, win: win };
+      });
+
+      var thFirst = { fontSize: 12, fontWeight: 600, color: "var(--dsh-mem-text-3)", textAlign: "left", padding: "4px 10px", borderBottom: "1px solid var(--dsh-mem-border)" };
+      var thStyle = { fontSize: 12, fontWeight: 600, color: "var(--dsh-mem-text-3)", textAlign: "right", padding: "4px 10px", borderBottom: "1px solid var(--dsh-mem-border)" };
+      var tdFirst = { fontSize: 12.5, fontWeight: 600, color: "var(--dsh-mem-text-1)", textAlign: "left", padding: "4px 10px" };
+      var tdStyle = { fontSize: 12.5, color: "var(--dsh-mem-text-1)", textAlign: "right", padding: "4px 10px", fontFamily: "ui-monospace, Consolas, monospace" };
+
+      return react.createElement(
+        "div", null,
+        react.createElement(
+          "div", { style: Object.assign({}, S.flexRow, { marginBottom: 10 }) },
+          react.createElement(Segmented, { value: layer, options: LAYER_OPTS, onChange: setLayer }),
+          react.createElement(Segmented, { value: granularity, options: GRAN_OPTS, onChange: setGranularity }),
+          react.createElement("div", { style: S.grow }),
+          react.createElement(NButton, { onClick: load }, "刷新"),
+        ),
+        error
+          ? react.createElement("div", { style: S.error }, "成本读取失败：" + error)
+          : null,
+        react.createElement("div", { style: S.panelLabel }, "成本趋势（按模型）"),
+        buckets.length > 0
+          ? react.createElement(
+              "div", null,
+              renderCostChart(buckets, models, maxY, fmtDate, fmtInt, PALETTE),
+              react.createElement(
+                "div", { style: { display: "flex", flexWrap: "wrap", gap: "4px 12px", margin: "6px 0 14px" } },
+                models.map(function (m, mi) {
+                  return react.createElement(
+                    "span", { key: "lg" + m, style: { display: "inline-flex", alignItems: "center", gap: 4, fontSize: 12, color: "var(--dsh-mem-text-2)" } },
+                    react.createElement("span", { style: { width: 10, height: 10, borderRadius: 2, background: PALETTE[mi % PALETTE.length], display: "inline-block" } }),
+                    m,
+                  );
+                }),
+              ),
+            )
+          : react.createElement("p", { style: S.muted }, data ? "当前层级暂无趋势数据。" : "加载中…"),
+        react.createElement("div", { style: S.panelLabel }, "层级成本（输出 token）"),
+        react.createElement(
+          "table", { style: { width: "100%", borderCollapse: "collapse", marginBottom: 14 } },
+          react.createElement(
+            "thead", null,
+            react.createElement(
+              "tr", null,
+              react.createElement("th", { style: thFirst }, "层级"),
+              ["day", "week", "month", "all"].map(function (r) {
+                return react.createElement("th", { key: r, style: thStyle }, RANGE_LABELS[r]);
+              }),
+            ),
+          ),
+          react.createElement(
+            "tbody", null,
+            layerTable.map(function (lc) {
+              return react.createElement(
+                "tr", { key: lc.layer },
+                react.createElement("td", { style: tdFirst }, lc.layer.toUpperCase()),
+                ["day", "week", "month", "all"].map(function (r) {
+                  var w = lc.win[r];
+                  return react.createElement("td", { key: r, style: tdStyle }, w ? fmtInt(w.outputTokens) : "0");
+                }),
+              );
+            }),
+          ),
+        ),
+        react.createElement("div", { style: S.panelLabel }, "层级成本（单次 avg）"),
+        react.createElement(
+          "table", { style: { width: "100%", borderCollapse: "collapse", marginBottom: 14 } },
+          react.createElement(
+            "thead", null,
+            react.createElement(
+              "tr", null,
+              react.createElement("th", { style: thFirst }, "层级"),
+              ["day", "week", "month", "all"].map(function (r) {
+                return react.createElement("th", { key: r, style: thStyle }, RANGE_LABELS[r] + "-avg");
+              }),
+            ),
+          ),
+          react.createElement(
+            "tbody", null,
+            layerTable.map(function (lc) {
+              return react.createElement(
+                "tr", { key: lc.layer },
+                react.createElement("td", { style: tdFirst }, lc.layer.toUpperCase()),
+                ["day", "week", "month", "all"].map(function (r) {
+                  var w = lc.win[r];
+                  return react.createElement("td", { key: r, style: tdStyle }, w ? fmtInt(w.avgOutputTokens) : "0");
+                }),
+              );
+            }),
+          ),
+        ),
+        react.createElement("div", { style: S.panelLabel }, "层级成本（单次 median）"),
+        react.createElement(
+          "table", { style: { width: "100%", borderCollapse: "collapse", marginBottom: 14 } },
+          react.createElement(
+            "thead", null,
+            react.createElement(
+              "tr", null,
+              react.createElement("th", { style: thFirst }, "层级"),
+              ["day", "week", "month", "all"].map(function (r) {
+                return react.createElement("th", { key: r, style: thStyle }, RANGE_LABELS[r] + "-median");
+              }),
+            ),
+          ),
+          react.createElement(
+            "tbody", null,
+            layerTable.map(function (lc) {
+              return react.createElement(
+                "tr", { key: lc.layer },
+                react.createElement("td", { style: tdFirst }, lc.layer.toUpperCase()),
+                ["day", "week", "month", "all"].map(function (r) {
+                  var w = lc.win[r];
+                  return react.createElement("td", { key: r, style: tdStyle }, w ? fmtInt(w.medianOutputTokens) : "0");
+                }),
+              );
+            }),
+          ),
+        ),
+        react.createElement("div", { style: S.panelLabel }, "时间窗口总览"),
+        react.createElement(
+          "div", { style: S.statGrid },
+          windows.map(function (w) {
+            return react.createElement(
+              "div", { key: w.range, className: "dsh-mem-card", style: S.statTile },
+              react.createElement("div", { style: S.statNum }, fmtInt(w.outputTokens + w.reasoningTokens)),
+              react.createElement("div", { style: S.statLabel }, RANGE_LABELS[w.range] + " · 总输出 token"),
+              react.createElement("div", { style: S.muted }, "文字 " + fmtInt(w.outputTokens) + " · 思考 " + fmtInt(w.reasoningTokens) + " · " + w.calls + " 次调用"),
+            );
+          }),
+        ),
+        byModel.length > 0
+          ? react.createElement(
+              "div", null,
+              react.createElement("div", { style: S.panelLabel }, "按模型（累计）"),
+              byModel.map(function (m) {
+                return react.createElement(
+                  "div", { key: "m-" + m.model, style: S.infoRow },
+                  react.createElement("span", { style: S.infoKey }, m.model),
+                  react.createElement("span", { style: S.infoVal }, m.calls + " 次 · 输出 " + fmtInt(m.outputTokens) + " · 思考 " + fmtInt(m.reasoningTokens)),
+                );
+              }),
+            )
+          : null,
+        data
+          ? react.createElement("p", { style: S.hint }, "输入按字符、输出/思考按 token 计；趋势图 Y 轴为输出 token，上方可切换层级与颗粒度。" )
+          : null,
+      );
+    }
+
     // ── 主面板：Tab 框架 ──
     var TABS = [
       ["overview", "概览"],
       ["records", "记忆"],
       ["scenes", "场景"],
       ["persona", "画像"],
+      ["cost", "成本"],
       ["log", "日志"],
     ];
 
@@ -2898,6 +3169,7 @@ window.__ModuleLoader__.load({
       else if (tab === "records") body = react.createElement(RecordsTab, { rpc: rpc });
       else if (tab === "scenes") body = react.createElement(ScenesTab, { rpc: rpc });
       else if (tab === "persona") body = react.createElement(PersonaTab, { rpc: rpc });
+      else if (tab === "cost") body = react.createElement(CostTab, { rpc: rpc });
       else body = react.createElement(LogTab, { rpc: rpc });
 
       return react.createElement(

--- a/dist/client.js
+++ b/dist/client.js
@@ -877,6 +877,15 @@ window.__ModuleLoader__.load({
         "  --dsh-mem-text-2: var(--dsw-alias-label-secondary, #61666b);",
         "  --dsh-mem-text-3: var(--dsw-alias-label-tertiary, #6e7781);",
         "  --dsh-mem-danger: var(--dsw-alias-state-error-primary, #d0403f);",
+        // 图表系列（成本折线图）：8 档固定色，PALETTE 只引用 var()；1 档锚品牌蓝，8 档中性"其他"
+        "  --dsh-mem-chart-1: #4d6bfe;",
+        "  --dsh-mem-chart-2: #0e9c8f;",
+        "  --dsh-mem-chart-3: #1f9d55;",
+        "  --dsh-mem-chart-4: #a8821c;",
+        "  --dsh-mem-chart-5: #d97a0d;",
+        "  --dsh-mem-chart-6: #d64570;",
+        "  --dsh-mem-chart-7: #7c5cff;",
+        "  --dsh-mem-chart-8: #61666b;",
         // 档位色 = 灰 → 品牌蓝 的渐变阶（chat/work 过渡蓝 / auto 品牌蓝）；
         // 文字对比度按 pill 真实底色（流光内底 = bg-card 97% + 档位色 3%）复算 AA 达标
         "  --dsh-mem-mode-chat: #5a69b0;",
@@ -908,6 +917,14 @@ window.__ModuleLoader__.load({
         "  --dsh-mem-text-2: var(--dsw-alias-label-secondary, #cfd3d6);",
         "  --dsh-mem-text-3: var(--dsw-alias-label-tertiary, #8892a6);",
         "  --dsh-mem-danger: var(--dsw-alias-state-error-primary, #f4707b);",
+        "  --dsh-mem-chart-1: #6e85ff;",
+        "  --dsh-mem-chart-2: #35c4b5;",
+        "  --dsh-mem-chart-3: #52c98d;",
+        "  --dsh-mem-chart-4: #d9b23e;",
+        "  --dsh-mem-chart-5: #f59e5b;",
+        "  --dsh-mem-chart-6: #f47ba2;",
+        "  --dsh-mem-chart-7: #a78bfa;",
+        "  --dsh-mem-chart-8: #8892a6;",
         "  --dsh-mem-mode-chat: #97a4ff;",
         "  --dsh-mem-mode-work: #8295ff;",
         "  --dsh-mem-mode-auto: #7b90ff;",
@@ -2894,7 +2911,7 @@ window.__ModuleLoader__.load({
       var RANGE_LABELS = { day: "今日", week: "本周", month: "本月", all: "累计" };
       var LAYER_OPTS = [{ key: "", label: "全部" }, { key: "l1", label: "L1" }, { key: "l2", label: "L2" }, { key: "l3", label: "L3" }];
       var GRAN_OPTS = [{ key: "day", label: "日" }, { key: "week", label: "周" }, { key: "month", label: "月" }];
-      var PALETTE = ["#4f8cff", "#ff7a45", "#34c98e", "#b26bff", "#ffc53d", "#ff5c8a", "#22c1c3", "#8c97a8"];
+      var PALETTE = ["var(--dsh-mem-chart-1)", "var(--dsh-mem-chart-2)", "var(--dsh-mem-chart-3)", "var(--dsh-mem-chart-4)", "var(--dsh-mem-chart-5)", "var(--dsh-mem-chart-6)", "var(--dsh-mem-chart-7)", "var(--dsh-mem-chart-8)"];
 
       var windows = (data && data.windows) || [];
       var byModel = (data && data.byModel) || [];
@@ -2975,7 +2992,7 @@ window.__ModuleLoader__.load({
                 models.map(function (m, mi) {
                   return react.createElement(
                     "span", { key: "lg" + m, style: { display: "inline-flex", alignItems: "center", gap: 4, fontSize: 12, color: "var(--dsh-mem-text-2)" } },
-                    react.createElement("span", { style: { width: 10, height: 10, borderRadius: 2, background: PALETTE[mi % PALETTE.length], display: "inline-block" } }),
+                    react.createElement("span", { style: { width: 10, height: 10, borderRadius: 4, background: PALETTE[mi % PALETTE.length], display: "inline-block" } }),
                     m,
                   );
                 }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -41,7 +41,7 @@ import { registerMemoryTools } from './tools/index.js';
 import { errDetail, withFileLog } from './util/filelog.js';
 import { resolveModelRoute, invalidateEffortCache } from './llm.js';
 import { effectiveCfg } from './pipeline/runner.js';
-import { initTokenCost } from './token-cost.js';
+import { initTokenCost, resetTokenCost } from './token-cost.js';
 export const name = 'dsh-memory-plugin';
 /** 硬依赖：蒸馏要用 llm，工具注册要用 tools，召回注入要用 systemPrompt。 */
 export const inject = ['llm', 'tools', 'systemPrompt'];
@@ -327,6 +327,7 @@ export async function apply(ctx, config) {
         return (async () => {
             await flushL0?.();
             db.close();
+            resetTokenCost();
         })();
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -41,6 +41,7 @@ import { registerMemoryTools } from './tools/index.js';
 import { errDetail, withFileLog } from './util/filelog.js';
 import { resolveModelRoute, invalidateEffortCache } from './llm.js';
 import { effectiveCfg } from './pipeline/runner.js';
+import { initTokenCost } from './token-cost.js';
 export const name = 'dsh-memory-plugin';
 /** 硬依赖：蒸馏要用 llm，工具注册要用 tools，召回注入要用 systemPrompt。 */
 export const inject = ['llm', 'tools', 'systemPrompt'];
@@ -113,6 +114,7 @@ export async function apply(ctx, config) {
     // ── 检索引擎（memory.db）与向量服务 ──
     const embed = initial.svc;
     const db = new MemoryDb(path.join(dataDir, 'memory.db'), initial.dims, logger);
+    initTokenCost(db);
     // 插件卸载时关闭连接（WAL 落盘），注册一次即可
     ctx.effect(() => () => db.close());
     let dbInit = { needsReindex: false };

--- a/dist/llm.js
+++ b/dist/llm.js
@@ -1,6 +1,7 @@
 import { createUserMessage, ReasoningEffortId } from '@deepseek-ai/dsh-llm';
 import { errDetail } from './util/filelog.js';
 import { recordDistillCall } from './llm-usage.js';
+import { recordCostCall } from './token-cost.js';
 // ── 分层输出预算（规格 C 节）：结构化蒸馏远用不到总闸级预算，逐层设护栏；
 //    模型跑偏时单次损失有界。数值"先试跑"状态，按线上截断率调整。
 /** L1 抽取（大输入块的 JSON 记忆数组输出）。 */
@@ -203,11 +204,15 @@ export async function callLLM(ctx, cfg, opts) {
         // 记账含失败路径（failures 计数；tokens 尽当时流内已到的 usage）
         if (opts.layer)
             recordDistillCall(opts.layer, user.length, outputTokens, reasoningTokens, true);
+        if (opts.layer)
+            recordCostCall(model, opts.layer, user.length, outputTokens, reasoningTokens);
         opts.logger?.warn(`[memory] LLM 调用失败 ${provider}/${model}（${((Date.now() - startedAt) / 1000).toFixed(1)}s）: ${errDetail(err)}`);
         throw err;
     }
     if (opts.layer)
         recordDistillCall(opts.layer, user.length, outputTokens, reasoningTokens, false);
+    if (opts.layer)
+        recordCostCall(model, opts.layer, user.length, outputTokens, reasoningTokens);
     const out = (blockText || deltaText).trim();
     if (out.length === 0) {
         // 空输出是最难排查的失败：流正常结束但一个字没吐。必须记录 finish 原因、

--- a/dist/llm.js
+++ b/dist/llm.js
@@ -205,14 +205,14 @@ export async function callLLM(ctx, cfg, opts) {
         if (opts.layer)
             recordDistillCall(opts.layer, user.length, outputTokens, reasoningTokens, true);
         if (opts.layer)
-            recordCostCall(model, opts.layer, user.length, outputTokens, reasoningTokens);
+            recordCostCall(provider, model, opts.layer, user.length, outputTokens, reasoningTokens);
         opts.logger?.warn(`[memory] LLM 调用失败 ${provider}/${model}（${((Date.now() - startedAt) / 1000).toFixed(1)}s）: ${errDetail(err)}`);
         throw err;
     }
     if (opts.layer)
         recordDistillCall(opts.layer, user.length, outputTokens, reasoningTokens, false);
     if (opts.layer)
-        recordCostCall(model, opts.layer, user.length, outputTokens, reasoningTokens);
+        recordCostCall(provider, model, opts.layer, user.length, outputTokens, reasoningTokens);
     const out = (blockText || deltaText).trim();
     if (out.length === 0) {
         // 空输出是最难排查的失败：流正常结束但一个字没吐。必须记录 finish 原因、

--- a/dist/stats.js
+++ b/dist/stats.js
@@ -152,7 +152,10 @@ async function handleEndpoint(endpoint, payload, deps) {
         case 'dsh-memory/token-cost': {
             const p = (payload ?? {});
             const granularity = p.granularity === 'week' || p.granularity === 'month' ? p.granularity : 'day';
-            return snapshotTokenCost(granularity);
+            // rangeDays 须为 1~365 的正整数（存储上限 365 天），否则回退默认窗口
+            const rawDays = p.rangeDays;
+            const rangeDays = typeof rawDays === 'number' && Number.isInteger(rawDays) && rawDays > 0 && rawDays <= 365 ? rawDays : 0;
+            return snapshotTokenCost(granularity, rangeDays);
         }
         case 'dsh-memory/session-mode-get': {
             if (!modes)

--- a/dist/stats.js
+++ b/dist/stats.js
@@ -14,6 +14,7 @@ import { effectiveCfg } from './pipeline/runner.js';
 import { emptyRecallStats } from './hooks/recall.js';
 import { decideSendableEffort, LAYER_DEFAULT_BUDGETS, resolveModelEfforts, resolveModelRoute } from './llm.js';
 import { errDetail } from './util/filelog.js';
+import { snapshotTokenCost } from './token-cost.js';
 const require = createRequire(import.meta.url);
 export const PLUGIN_VERSION = require('../package.json').version;
 /** 注册状态 RPC（web 侧 connection 服务可选，缺失时跳过，不影响插件主体）。 */
@@ -148,6 +149,11 @@ async function handleEndpoint(endpoint, payload, deps) {
     switch (endpoint) {
         case 'dsh-memory/stats':
             return buildStats(cfg, stores, status);
+        case 'dsh-memory/token-cost': {
+            const p = (payload ?? {});
+            const granularity = p.granularity === 'week' || p.granularity === 'month' ? p.granularity : 'day';
+            return snapshotTokenCost(granularity);
+        }
         case 'dsh-memory/session-mode-get': {
             if (!modes)
                 throw new Error('档位存储未初始化');

--- a/dist/store/sqlite.d.ts
+++ b/dist/store/sqlite.d.ts
@@ -22,6 +22,7 @@ export interface CostAggregate {
 }
 /** 按 model 分组的成本行（成本看板用）。 */
 export interface CostByModel {
+    provider: string;
     model: string;
     calls: number;
     inputChars: number;
@@ -38,9 +39,10 @@ export interface CostByLayer {
     avgOutputTokens: number;
     medianOutputTokens: number;
 }
-/** 按时间桶 + model 聚合的扁平行（趋势图与日均/周均/月均 + 中位数统计共用）。 */
+/** 按时间桶 + provider/model 聚合的扁平行（趋势图与日均/周均/月均 + 中位数统计共用）。 */
 export interface BucketRow {
     bucket: number;
+    provider: string;
     model: string;
     calls: number;
     outputTokens: number;
@@ -81,6 +83,9 @@ export declare class MemoryDb {
     private stmtL1FtsDelete;
     private stmtL1FtsSearch;
     private stmtL1FtsSearchFamily;
+    /** token_cost 明细写入 / 滚动清理语句（构造期 prepare 缓存）。 */
+    private stmtInsertCost;
+    private stmtDeleteCost;
     private stmtUpsertL0;
     private stmtGetL0;
     /** 主表存在性点查（同 L1：防御性 FTS 删除的前置判断）。 */
@@ -184,9 +189,9 @@ export declare class MemoryDb {
     upsertL0Batch(records: L0MessageRecord[], embeddings?: Array<Float32Array | undefined>): boolean;
     /**
      * 记录一次蒸馏调用成本（明细表，365 天滚动清理）。
-     * 失败/成功都记（token 照烧）；记账失败不阻断蒸馏（成本看板是增强能力）。
+     * 失败/成功都记（token 照烧）；记账失败记 warn 但不阻断蒸馏（成本看板是增强能力）。
      */
-    insertCostCall(model: string, layer: string, inputChars: number, outputTokens: number, reasoningTokens: number): void;
+    insertCostCall(provider: string, model: string, layer: string, inputChars: number, outputTokens: number, reasoningTokens: number): void;
     /**
      * 查询 token_cost 单窗口聚合（成本看板用；since 为毫秒起点，0 = 全量）。
      * 输入口径：inputChars 是字符（llm 流拿不到输入 token，沿用 llm-usage 的字符折算口径）。

--- a/dist/store/sqlite.d.ts
+++ b/dist/store/sqlite.d.ts
@@ -9,6 +9,43 @@ export interface StoreCapabilities {
     ftsSearch: boolean;
     vectorSearch: boolean;
 }
+/** token_cost 单窗口成本聚合（成本看板用）。 */
+export interface CostAggregate {
+    calls: number;
+    inputChars: number;
+    outputTokens: number;
+    reasoningTokens: number;
+    /** 单次调用输出 token 均值（无数据为 0）。 */
+    avgOutputTokens: number;
+    /** 单次调用输出 token 中位数（无数据为 0）。 */
+    medianOutputTokens: number;
+}
+/** 按 model 分组的成本行（成本看板用）。 */
+export interface CostByModel {
+    model: string;
+    calls: number;
+    inputChars: number;
+    outputTokens: number;
+    reasoningTokens: number;
+}
+/** 按层级（l1/l2/l3 归并）分组的成本行。 */
+export interface CostByLayer {
+    layer: string;
+    calls: number;
+    inputChars: number;
+    outputTokens: number;
+    reasoningTokens: number;
+    avgOutputTokens: number;
+    medianOutputTokens: number;
+}
+/** 按时间桶 + model 聚合的扁平行（趋势图与日均/周均/月均 + 中位数统计共用）。 */
+export interface BucketRow {
+    bucket: number;
+    model: string;
+    calls: number;
+    outputTokens: number;
+    reasoningTokens: number;
+}
 /** L1 检索命中（含 BM25/余弦归一分数）。 */
 export interface L1SearchHit {
     id: string;
@@ -145,6 +182,32 @@ export declare class MemoryDb {
     searchL1Vector(embedding: Float32Array, topK: number, family?: string): L1SearchHit[];
     /** 批量 upsert L0 消息（元数据 + FTS；embeddings 与 records 等长，可省略）。 */
     upsertL0Batch(records: L0MessageRecord[], embeddings?: Array<Float32Array | undefined>): boolean;
+    /**
+     * 记录一次蒸馏调用成本（明细表，365 天滚动清理）。
+     * 失败/成功都记（token 照烧）；记账失败不阻断蒸馏（成本看板是增强能力）。
+     */
+    insertCostCall(model: string, layer: string, inputChars: number, outputTokens: number, reasoningTokens: number): void;
+    /**
+     * 查询 token_cost 单窗口聚合（成本看板用；since 为毫秒起点，0 = 全量）。
+     * 输入口径：inputChars 是字符（llm 流拿不到输入 token，沿用 llm-usage 的字符折算口径）。
+     * 成本看板是增强能力：降级态/查询异常一律返回零值，不向上抛错。
+     * median 需取 output_tokens 序列在 JS 侧算（SQLite 无内置 median 函数）。
+     */
+    aggregateCost(since: number): {
+        total: CostAggregate;
+        byModel: CostByModel[];
+    };
+    /**
+     * 按层级归并聚合（l1 = l1-extract + l1-dedup；成本看板层级表格用）。
+     * 降级/异常返回空数组，不抛错。
+     */
+    aggregateCostByLayer(since: number): CostByLayer[];
+    /**
+     * 按时间桶（bucketMs 毫秒）+ model 聚合，返回扁平行。
+     * offsetMs 把桶边界对齐本地时区；layer 为空=全部，'l1' 归并 extract/dedup，其余精确匹配。
+     * 趋势图与「日均/周均/月均 + 中位数」统计共用：JS 侧按不同 bucketMs 调三次再聚合。
+     */
+    aggregateByBucket(bucketMs: number, offsetMs: number, since: number, layer: string): BucketRow[];
     countL0(): number;
     /** 统计 recorded_at >= iso 的消息数（状态面板"今日捕获"用）。 */
     countL0Since(iso: string): number;

--- a/dist/store/sqlite.js
+++ b/dist/store/sqlite.js
@@ -35,6 +35,17 @@ function chunkIds(ids) {
         out.push(ids.slice(i, i + IN_CHUNK));
     return out;
 }
+function emptyCostAggregate() {
+    return { calls: 0, inputChars: 0, outputTokens: 0, reasoningTokens: 0, avgOutputTokens: 0, medianOutputTokens: 0 };
+}
+/** 已排序序列的中位数（偶数个取中间两者平均；空返回 0）。 */
+function medianOf(sorted) {
+    const n = sorted.length;
+    if (n === 0)
+        return 0;
+    const mid = Math.floor(n / 2);
+    return n % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
 export class MemoryDb {
     db;
     degraded = false;
@@ -325,6 +336,18 @@ export class MemoryDb {
         this.stmtGetL0 = this.db.prepare('SELECT session_id, role, message_text, recorded_at, timestamp FROM l0_conversations WHERE record_id = ?');
         this.stmtL0Exists = this.db.prepare('SELECT 1 FROM l0_conversations WHERE record_id = ?');
         this.prepareL0VecStatements();
+        // ── token_cost：蒸馏成本明细表（成本看板用；365 天滚动清理） ──
+        this.db.exec(`
+      CREATE TABLE IF NOT EXISTS token_cost (
+        ts INTEGER NOT NULL,
+        model TEXT NOT NULL,
+        layer TEXT NOT NULL,
+        input_chars INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        reasoning_tokens INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+        this.db.exec('CREATE INDEX IF NOT EXISTS idx_token_cost_ts ON token_cost(ts)');
         // ── FTS5 全文索引（建表失败仅停用 FTS，不降级整个库） ──
         try {
             // 索引重建判据（FTS5 无法 ALTER，只能 drop 后从源表全量回灌）：
@@ -962,6 +985,134 @@ export class MemoryDb {
             }
             this.logger?.warn(`${TAG} L0 批量写入失败: ${err instanceof Error ? err.message : String(err)}`);
             return false;
+        }
+    }
+    /**
+     * 记录一次蒸馏调用成本（明细表，365 天滚动清理）。
+     * 失败/成功都记（token 照烧）；记账失败不阻断蒸馏（成本看板是增强能力）。
+     */
+    insertCostCall(model, layer, inputChars, outputTokens, reasoningTokens) {
+        if (this.degraded)
+            return;
+        try {
+            this.db.prepare('INSERT INTO token_cost (ts, model, layer, input_chars, output_tokens, reasoning_tokens) VALUES (?, ?, ?, ?, ?, ?)').run(Date.now(), model, layer, Math.max(0, Math.round(inputChars)), Math.max(0, Math.round(outputTokens)), Math.max(0, Math.round(reasoningTokens)));
+            this.db.prepare('DELETE FROM token_cost WHERE ts < ?').run(Date.now() - 365 * 24 * 3600_000);
+        }
+        catch {
+            /* 记账失败不阻断蒸馏 */
+        }
+    }
+    /**
+     * 查询 token_cost 单窗口聚合（成本看板用；since 为毫秒起点，0 = 全量）。
+     * 输入口径：inputChars 是字符（llm 流拿不到输入 token，沿用 llm-usage 的字符折算口径）。
+     * 成本看板是增强能力：降级态/查询异常一律返回零值，不向上抛错。
+     * median 需取 output_tokens 序列在 JS 侧算（SQLite 无内置 median 函数）。
+     */
+    aggregateCost(since) {
+        if (this.degraded)
+            return { total: emptyCostAggregate(), byModel: [] };
+        try {
+            const total = this.db
+                .prepare(`SELECT COUNT(*) AS calls,
+                  COALESCE(SUM(input_chars), 0) AS inputChars,
+                  COALESCE(SUM(output_tokens), 0) AS outputTokens,
+                  COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens,
+                  COALESCE(AVG(output_tokens), 0) AS avgOutputTokens
+             FROM token_cost WHERE ts >= ?`)
+                .get(since);
+            const tokenRows = this.db
+                .prepare('SELECT output_tokens FROM token_cost WHERE ts >= ? ORDER BY output_tokens')
+                .all(since);
+            const byModel = this.db
+                .prepare(`SELECT model, COUNT(*) AS calls,
+                  COALESCE(SUM(input_chars), 0) AS inputChars,
+                  COALESCE(SUM(output_tokens), 0) AS outputTokens,
+                  COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens
+             FROM token_cost WHERE ts >= ? GROUP BY model ORDER BY outputTokens DESC`)
+                .all(since);
+            return {
+                total: {
+                    calls: total.calls,
+                    inputChars: total.inputChars,
+                    outputTokens: total.outputTokens,
+                    reasoningTokens: total.reasoningTokens,
+                    avgOutputTokens: total.avgOutputTokens,
+                    medianOutputTokens: medianOf(tokenRows.map((r) => r.output_tokens)),
+                },
+                byModel,
+            };
+        }
+        catch {
+            return { total: emptyCostAggregate(), byModel: [] };
+        }
+    }
+    /**
+     * 按层级归并聚合（l1 = l1-extract + l1-dedup；成本看板层级表格用）。
+     * 降级/异常返回空数组，不抛错。
+     */
+    aggregateCostByLayer(since) {
+        if (this.degraded)
+            return [];
+        try {
+            const rows = this.db
+                .prepare(`SELECT CASE WHEN layer IN ('l1-extract','l1-dedup') THEN 'l1' ELSE layer END AS layer,
+                  COUNT(*) AS calls,
+                  COALESCE(SUM(input_chars), 0) AS inputChars,
+                  COALESCE(SUM(output_tokens), 0) AS outputTokens,
+                  COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens,
+                  COALESCE(AVG(output_tokens), 0) AS avgOutputTokens
+             FROM token_cost WHERE ts >= ? GROUP BY layer ORDER BY layer`)
+                .all(since);
+            // 中位数需取 output_tokens 序列在 JS 侧算（SQLite 无内置 median）
+            const tokenRows = this.db
+                .prepare(`SELECT CASE WHEN layer IN ('l1-extract','l1-dedup') THEN 'l1' ELSE layer END AS layer,
+                  output_tokens
+             FROM token_cost WHERE ts >= ? ORDER BY layer, output_tokens`)
+                .all(since);
+            const medianByLayer = new Map();
+            for (const r of tokenRows) {
+                const arr = medianByLayer.get(r.layer);
+                if (arr)
+                    arr.push(r.output_tokens);
+                else
+                    medianByLayer.set(r.layer, [r.output_tokens]);
+            }
+            return rows.map((r) => ({
+                ...r,
+                medianOutputTokens: medianOf(medianByLayer.get(r.layer) ?? []),
+            }));
+        }
+        catch {
+            return [];
+        }
+    }
+    /**
+     * 按时间桶（bucketMs 毫秒）+ model 聚合，返回扁平行。
+     * offsetMs 把桶边界对齐本地时区；layer 为空=全部，'l1' 归并 extract/dedup，其余精确匹配。
+     * 趋势图与「日均/周均/月均 + 中位数」统计共用：JS 侧按不同 bucketMs 调三次再聚合。
+     */
+    aggregateByBucket(bucketMs, offsetMs, since, layer) {
+        if (this.degraded)
+            return [];
+        try {
+            let sql = `SELECT CAST((ts + ?) / ? AS INTEGER) AS bucket, model,
+                COUNT(*) AS calls,
+                COALESCE(SUM(output_tokens), 0) AS outputTokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens
+           FROM token_cost WHERE ts >= ?`;
+            const params = [offsetMs, bucketMs, since];
+            if (layer === 'l1') {
+                sql += ` AND layer IN ('l1-extract','l1-dedup')`;
+            }
+            else if (layer) {
+                sql += ` AND layer = ?`;
+                params.push(layer);
+            }
+            sql += ` GROUP BY bucket, model ORDER BY bucket, model`;
+            return this.db.prepare(sql).all(...params);
+        }
+        catch {
+            return [];
         }
     }
     countL0() {

--- a/dist/store/sqlite.js
+++ b/dist/store/sqlite.js
@@ -67,6 +67,9 @@ export class MemoryDb {
     stmtL1FtsDelete;
     stmtL1FtsSearch;
     stmtL1FtsSearchFamily;
+    /** token_cost 明细写入 / 滚动清理语句（构造期 prepare 缓存）。 */
+    stmtInsertCost;
+    stmtDeleteCost;
     stmtUpsertL0;
     stmtGetL0;
     /** 主表存在性点查（同 L1：防御性 FTS 删除的前置判断）。 */
@@ -340,6 +343,7 @@ export class MemoryDb {
         this.db.exec(`
       CREATE TABLE IF NOT EXISTS token_cost (
         ts INTEGER NOT NULL,
+        provider TEXT NOT NULL,
         model TEXT NOT NULL,
         layer TEXT NOT NULL,
         input_chars INTEGER NOT NULL DEFAULT 0,
@@ -347,7 +351,13 @@ export class MemoryDb {
         reasoning_tokens INTEGER NOT NULL DEFAULT 0
       )
     `);
+        // 迁移：provider/model 复合键引入前的旧表补 provider 列（历史行回填 unknown）
+        if (this.tableExists('token_cost') && !this.hasColumn('token_cost', 'provider')) {
+            this.db.exec("ALTER TABLE token_cost ADD COLUMN provider TEXT NOT NULL DEFAULT 'unknown'");
+        }
         this.db.exec('CREATE INDEX IF NOT EXISTS idx_token_cost_ts ON token_cost(ts)');
+        this.stmtInsertCost = this.db.prepare('INSERT INTO token_cost (ts, provider, model, layer, input_chars, output_tokens, reasoning_tokens) VALUES (?, ?, ?, ?, ?, ?, ?)');
+        this.stmtDeleteCost = this.db.prepare('DELETE FROM token_cost WHERE ts < ?');
         // ── FTS5 全文索引（建表失败仅停用 FTS，不降级整个库） ──
         try {
             // 索引重建判据（FTS5 无法 ALTER，只能 drop 后从源表全量回灌）：
@@ -1003,17 +1013,17 @@ export class MemoryDb {
     }
     /**
      * 记录一次蒸馏调用成本（明细表，365 天滚动清理）。
-     * 失败/成功都记（token 照烧）；记账失败不阻断蒸馏（成本看板是增强能力）。
+     * 失败/成功都记（token 照烧）；记账失败记 warn 但不阻断蒸馏（成本看板是增强能力）。
      */
-    insertCostCall(model, layer, inputChars, outputTokens, reasoningTokens) {
+    insertCostCall(provider, model, layer, inputChars, outputTokens, reasoningTokens) {
         if (this.degraded)
             return;
         try {
-            this.db.prepare('INSERT INTO token_cost (ts, model, layer, input_chars, output_tokens, reasoning_tokens) VALUES (?, ?, ?, ?, ?, ?)').run(Date.now(), model, layer, Math.max(0, Math.round(inputChars)), Math.max(0, Math.round(outputTokens)), Math.max(0, Math.round(reasoningTokens)));
-            this.db.prepare('DELETE FROM token_cost WHERE ts < ?').run(Date.now() - 365 * 24 * 3600_000);
+            this.stmtInsertCost.run(Date.now(), provider, model, layer, Math.max(0, Math.round(inputChars)), Math.max(0, Math.round(outputTokens)), Math.max(0, Math.round(reasoningTokens)));
+            this.stmtDeleteCost.run(Date.now() - 365 * 24 * 3600_000);
         }
-        catch {
-            /* 记账失败不阻断蒸馏 */
+        catch (err) {
+            this.logger?.warn(`${TAG} token_cost 记账失败: ${err instanceof Error ? err.message : String(err)}`);
         }
     }
     /**
@@ -1038,11 +1048,11 @@ export class MemoryDb {
                 .prepare('SELECT output_tokens FROM token_cost WHERE ts >= ? ORDER BY output_tokens')
                 .all(since);
             const byModel = this.db
-                .prepare(`SELECT model, COUNT(*) AS calls,
+                .prepare(`SELECT provider, model, COUNT(*) AS calls,
                   COALESCE(SUM(input_chars), 0) AS inputChars,
                   COALESCE(SUM(output_tokens), 0) AS outputTokens,
                   COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens
-             FROM token_cost WHERE ts >= ? GROUP BY model ORDER BY outputTokens DESC`)
+             FROM token_cost WHERE ts >= ? GROUP BY provider, model ORDER BY outputTokens DESC`)
                 .all(since);
             return {
                 total: {
@@ -1109,7 +1119,7 @@ export class MemoryDb {
         if (this.degraded)
             return [];
         try {
-            let sql = `SELECT CAST((ts + ?) / ? AS INTEGER) AS bucket, model,
+            let sql = `SELECT CAST((ts + ?) / ? AS INTEGER) AS bucket, provider, model,
                 COUNT(*) AS calls,
                 COALESCE(SUM(output_tokens), 0) AS outputTokens,
                 COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens
@@ -1122,7 +1132,7 @@ export class MemoryDb {
                 sql += ` AND layer = ?`;
                 params.push(layer);
             }
-            sql += ` GROUP BY bucket, model ORDER BY bucket, model`;
+            sql += ` GROUP BY bucket, provider, model ORDER BY bucket, provider, model`;
             return this.db.prepare(sql).all(...params);
         }
         catch {

--- a/dist/token-cost.d.ts
+++ b/dist/token-cost.d.ts
@@ -1,0 +1,88 @@
+/**
+ * 蒸馏成本看板账本：把每次蒸馏调用（model × layer）的 token 成本写入 SQLite 明细表。
+ *
+ * 模块级单例 + init 注入 db：callLLM 拿不到 db（db 在 index.ts 运行时创建），
+ * 故通过 initTokenCost(db) 在插件启动时注入；recordCostCall 每次调用写一行明细。
+ *
+ * 与作者 llm-usage.ts 的关系：作者是"按 layer 累计的纯内存计数器"（给 bench 用）；
+ * 本模块补上三个缺口——按 model 分组、持久化（365 天明细）、面向 UI 成本看板。
+ */
+import type { DistillLayer } from './llm-usage.js';
+import type { CostByModel, MemoryDb } from './store/sqlite.js';
+/** 插件启动时注入 db（index.ts 调用）。 */
+export declare function initTokenCost(d: MemoryDb): void;
+/** 记录一次蒸馏调用成本（callLLM 出口调用；model 由调用方传入）。 */
+export declare function recordCostCall(model: string, layer: DistillLayer, inputChars: number, outputTokens: number, reasoningTokens: number): void;
+/** 成本看板单个时间窗口（day/week/month/all）。 */
+export interface CostWindow {
+    range: 'day' | 'week' | 'month' | 'all';
+    /** 窗口起点（毫秒；all 为 0）。 */
+    since: number;
+    calls: number;
+    inputChars: number;
+    outputTokens: number;
+    reasoningTokens: number;
+    avgOutputTokens: number;
+    medianOutputTokens: number;
+}
+/** 成本看板时间粒度（趋势图 + 统计口径共用）。 */
+export type Granularity = 'day' | 'week' | 'month';
+/** 每模型统计指标（层级表格行；均值按活跃桶口径，中位数按活跃桶序列）。 */
+export interface ModelMetrics {
+    model: string;
+    dayCalls: number;
+    weekCalls: number;
+    monthCalls: number;
+    dayOutput: number;
+    dayMedian: number;
+    weekOutput: number;
+    weekMedian: number;
+    monthOutput: number;
+    monthMedian: number;
+}
+/** 每层级（l1/l2/l3）的模型统计（层级表格）。 */
+export interface LayerMetrics {
+    layer: 'l1' | 'l2' | 'l3';
+    models: ModelMetrics[];
+}
+/** 层级 × 窗口矩阵里的单个窗口格子。 */
+export interface LayerWindow {
+    range: 'day' | 'week' | 'month' | 'all';
+    calls: number;
+    inputChars: number;
+    outputTokens: number;
+    reasoningTokens: number;
+    avgOutputTokens: number;
+    medianOutputTokens: number;
+}
+/** 单个层级在四个窗口的聚合（层级×窗口表格行）。 */
+export interface LayerCost {
+    layer: 'l1' | 'l2' | 'l3';
+    windows: LayerWindow[];
+}
+/** 趋势单桶。 */
+export interface TrendBucket {
+    ts: number;
+    total: number;
+    byModel: Record<string, number>;
+}
+/** 趋势快照：三个层级各一份连续桶序列。 */
+export interface TrendSnapshot {
+    granularity: Granularity;
+    byLayer: Record<'l1' | 'l2' | 'l3', TrendBucket[]>;
+}
+/** 成本看板快照（dsh-memory/token-cost 端点返回值）。 */
+export interface CostSnapshot {
+    /** day/week/month/all 四窗口聚合。 */
+    windows: CostWindow[];
+    /** 全量窗口（all）按 model 分组。 */
+    byModel: CostByModel[];
+    /** 按层级（l1/l2/l3 归并）在四个窗口的聚合（层级×窗口表格）。 */
+    byLayer: LayerCost[];
+    /** 每层级的模型统计指标（层级表格）。 */
+    byLayerStats: LayerMetrics[];
+    /** 趋势图数据。 */
+    trend: TrendSnapshot;
+}
+/** 读成本看板快照（db 未注入/降级时返回全零结构，不抛错）。 */
+export declare function snapshotTokenCost(granularity: Granularity): CostSnapshot;

--- a/dist/token-cost.d.ts
+++ b/dist/token-cost.d.ts
@@ -11,8 +11,10 @@ import type { DistillLayer } from './llm-usage.js';
 import type { CostByModel, MemoryDb } from './store/sqlite.js';
 /** 插件启动时注入 db（index.ts 调用）。 */
 export declare function initTokenCost(d: MemoryDb): void;
-/** 记录一次蒸馏调用成本（callLLM 出口调用；model 由调用方传入）。 */
-export declare function recordCostCall(model: string, layer: DistillLayer, inputChars: number, outputTokens: number, reasoningTokens: number): void;
+/** 插件卸载时清空 db 引用（index.ts 的 ctx.effect 清理里调用，防悬空引用）。 */
+export declare function resetTokenCost(): void;
+/** 记录一次蒸馏调用成本（callLLM 出口调用；provider/model 由调用方传入）。 */
+export declare function recordCostCall(provider: string, model: string, layer: DistillLayer, inputChars: number, outputTokens: number, reasoningTokens: number): void;
 /** 成本看板单个时间窗口（day/week/month/all）。 */
 export interface CostWindow {
     range: 'day' | 'week' | 'month' | 'all';
@@ -27,7 +29,7 @@ export interface CostWindow {
 }
 /** 成本看板时间粒度（趋势图 + 统计口径共用）。 */
 export type Granularity = 'day' | 'week' | 'month';
-/** 每模型统计指标（层级表格行；均值按活跃桶口径，中位数按活跃桶序列）。 */
+/** 每模型统计指标（层级表格行；均值/中位数按 since=0 全量历史的活跃桶口径，非「最近窗口」）。 */
 export interface ModelMetrics {
     model: string;
     dayCalls: number;
@@ -84,5 +86,5 @@ export interface CostSnapshot {
     /** 趋势图数据。 */
     trend: TrendSnapshot;
 }
-/** 读成本看板快照（db 未注入/降级时返回全零结构，不抛错）。 */
-export declare function snapshotTokenCost(granularity: Granularity): CostSnapshot;
+/** 读成本看板快照（db 未注入/降级时返回全零结构，不抛错；rangeDays>0 = 趋势展示近 N 天）。 */
+export declare function snapshotTokenCost(granularity: Granularity, rangeDays: number): CostSnapshot;

--- a/dist/token-cost.js
+++ b/dist/token-cost.js
@@ -161,15 +161,16 @@ export function snapshotTokenCost(granularity, rangeDays) {
     const offset = localOffsetMs();
     const byLayerStats = [];
     const trendByLayer = { l1: [], l2: [], l3: [] };
-    // 趋势展示范围：rangeDays > 0 = 近 N 天（since + 桶数按 N 折算）；否则用默认窗口
+    // 趋势展示范围：rangeDays > 0 = 近 N 天（强制按「日」粒度出 N 个日桶，不受周/月聚合影响）；否则用默认窗口
+    const trendGranularity = rangeDays > 0 ? 'day' : granularity;
     const trendSince = rangeDays > 0 ? now - rangeDays * 24 * 3600_000 : 0;
-    const trendCount = rangeDays > 0 ? Math.max(1, Math.ceil((rangeDays * 24 * 3600_000) / TREND_MS[granularity])) : TREND_COUNT[granularity];
+    const trendCount = rangeDays > 0 ? rangeDays : TREND_COUNT[granularity];
     for (const layer of LAYERS) {
         const dayRows = d.aggregateByBucket(TREND_MS.day, offset, 0, layer);
         const weekRows = d.aggregateByBucket(TREND_MS.week, offset, 0, layer);
         const monthRows = d.aggregateByBucket(TREND_MS.month, offset, 0, layer);
         byLayerStats.push({ layer, models: buildModelMetrics(dayRows, weekRows, monthRows) });
-        trendByLayer[layer] = buildTrend(d.aggregateByBucket(TREND_MS[granularity], offset, trendSince, layer), granularity, now, trendCount);
+        trendByLayer[layer] = buildTrend(d.aggregateByBucket(TREND_MS[trendGranularity], offset, trendSince, layer), trendGranularity, now, trendCount);
     }
-    return { windows, byModel, byLayer, byLayerStats, trend: { granularity, byLayer: trendByLayer } };
+    return { windows, byModel, byLayer, byLayerStats, trend: { granularity: trendGranularity, byLayer: trendByLayer } };
 }

--- a/dist/token-cost.js
+++ b/dist/token-cost.js
@@ -1,0 +1,164 @@
+let db = null;
+/** 插件启动时注入 db（index.ts 调用）。 */
+export function initTokenCost(d) {
+    db = d;
+}
+/** 记录一次蒸馏调用成本（callLLM 出口调用；model 由调用方传入）。 */
+export function recordCostCall(model, layer, inputChars, outputTokens, reasoningTokens) {
+    if (!db)
+        return;
+    db.insertCostCall(model, layer, inputChars, outputTokens, reasoningTokens);
+}
+/** 四窗口定义：range + 回看毫秒数（all 的 ms 恒 0）。 */
+const WINDOW_DEFS = [
+    { range: 'day', ms: 24 * 3600_000 },
+    { range: 'week', ms: 7 * 24 * 3600_000 },
+    { range: 'month', ms: 30 * 24 * 3600_000 },
+    { range: 'all', ms: 0 },
+];
+/** 趋势桶宽（毫秒）与桶数。 */
+const TREND_MS = { day: 24 * 3600_000, week: 7 * 24 * 3600_000, month: 30 * 24 * 3600_000 };
+const TREND_COUNT = { day: 30, week: 12, month: 12 };
+/** 三个归并层级。 */
+const LAYERS = ['l1', 'l2', 'l3'];
+/** 本地时区偏移（东正西负）：把 SQL 端 UTC epoch 桶边界对齐到本地午夜。 */
+function localOffsetMs() {
+    return -new Date().getTimezoneOffset() * 60_000;
+}
+/** 已排序序列的中位数（偶数取中间两者平均；空返回 0）。 */
+function medianOf(sorted) {
+    const n = sorted.length;
+    if (n === 0)
+        return 0;
+    const mid = Math.floor(n / 2);
+    return n % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+/** 从某模型某粒度的 bucket 序列算均值/中位数（活跃桶口径：只除有调用的桶数）。 */
+function statOf(rows) {
+    const active = rows.filter((r) => r.calls > 0);
+    if (active.length === 0)
+        return { avgCalls: 0, avgOutput: 0, medianOutput: 0 };
+    const calls = active.reduce((s, r) => s + r.calls, 0);
+    const output = active.reduce((s, r) => s + r.outputTokens, 0);
+    return {
+        avgCalls: calls / active.length,
+        avgOutput: output / active.length,
+        medianOutput: medianOf(active.map((r) => r.outputTokens).sort((a, b) => a - b)),
+    };
+}
+/** 从 day/week/month 三组 bucket 行组装每个模型的统计指标。 */
+function buildModelMetrics(dayRows, weekRows, monthRows) {
+    const models = new Set();
+    for (const r of dayRows)
+        models.add(r.model);
+    for (const r of weekRows)
+        models.add(r.model);
+    for (const r of monthRows)
+        models.add(r.model);
+    return Array.from(models)
+        .sort()
+        .map((model) => {
+        const d = statOf(dayRows.filter((r) => r.model === model));
+        const w = statOf(weekRows.filter((r) => r.model === model));
+        const m = statOf(monthRows.filter((r) => r.model === model));
+        return {
+            model,
+            dayCalls: d.avgCalls,
+            weekCalls: w.avgCalls,
+            monthCalls: m.avgCalls,
+            dayOutput: d.avgOutput,
+            dayMedian: d.medianOutput,
+            weekOutput: w.avgOutput,
+            weekMedian: w.medianOutput,
+            monthOutput: m.avgOutput,
+            monthMedian: m.medianOutput,
+        };
+    });
+}
+/** 从某层级某粒度的 bucket 行生成连续趋势桶（空桶补 0）。 */
+function buildTrend(rows, granularity, now) {
+    const bucketMs = TREND_MS[granularity];
+    const count = TREND_COUNT[granularity];
+    const offset = localOffsetMs();
+    const cur = Math.floor((now + offset) / bucketMs);
+    const buckets = [];
+    for (let i = count - 1; i >= 0; i--) {
+        const b = cur - i;
+        buckets.push({ ts: b * bucketMs - offset, total: 0, byModel: {} });
+    }
+    for (const r of rows) {
+        const idx = count - 1 - (cur - r.bucket);
+        if (idx < 0 || idx >= count)
+            continue;
+        const tb = buckets[idx];
+        tb.total += r.outputTokens;
+        tb.byModel[r.model] = (tb.byModel[r.model] ?? 0) + r.outputTokens;
+    }
+    return buckets;
+}
+/** 读成本看板快照（db 未注入/降级时返回全零结构，不抛错）。 */
+export function snapshotTokenCost(granularity) {
+    const now = Date.now();
+    const emptyWindow = (range, ms) => ({
+        range,
+        since: ms === 0 ? 0 : now - ms,
+        calls: 0,
+        inputChars: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        avgOutputTokens: 0,
+        medianOutputTokens: 0,
+    });
+    if (!db) {
+        return {
+            windows: WINDOW_DEFS.map((w) => emptyWindow(w.range, w.ms)),
+            byModel: [],
+            byLayer: [],
+            byLayerStats: [],
+            trend: { granularity, byLayer: { l1: [], l2: [], l3: [] } },
+        };
+    }
+    // 四窗口总聚合（累计窗口顺带取 byModel）
+    const d = db;
+    const windows = [];
+    let byModel = [];
+    for (const w of WINDOW_DEFS) {
+        const since = w.ms === 0 ? 0 : now - w.ms;
+        const agg = d.aggregateCost(since);
+        windows.push({ range: w.range, since, ...agg.total });
+        if (w.range === 'all')
+            byModel = agg.byModel;
+    }
+    // 按层级 × 窗口聚合（层级×窗口表格）：每个窗口调一次 aggregateCostByLayer，再按层组装
+    const layerByWindow = WINDOW_DEFS.map((w) => {
+        const since = w.ms === 0 ? 0 : now - w.ms;
+        return { range: w.range, rows: d.aggregateCostByLayer(since) };
+    });
+    const byLayer = LAYERS.map((layer) => ({
+        layer,
+        windows: layerByWindow.map(({ range, rows }) => {
+            const row = rows.find((r) => r.layer === layer);
+            return {
+                range,
+                calls: row?.calls ?? 0,
+                inputChars: row?.inputChars ?? 0,
+                outputTokens: row?.outputTokens ?? 0,
+                reasoningTokens: row?.reasoningTokens ?? 0,
+                avgOutputTokens: row?.avgOutputTokens ?? 0,
+                medianOutputTokens: row?.medianOutputTokens ?? 0,
+            };
+        }),
+    }));
+    // 每层级模型统计 + 趋势
+    const offset = localOffsetMs();
+    const byLayerStats = [];
+    const trendByLayer = { l1: [], l2: [], l3: [] };
+    for (const layer of LAYERS) {
+        const dayRows = d.aggregateByBucket(TREND_MS.day, offset, 0, layer);
+        const weekRows = d.aggregateByBucket(TREND_MS.week, offset, 0, layer);
+        const monthRows = d.aggregateByBucket(TREND_MS.month, offset, 0, layer);
+        byLayerStats.push({ layer, models: buildModelMetrics(dayRows, weekRows, monthRows) });
+        trendByLayer[layer] = buildTrend(d.aggregateByBucket(TREND_MS[granularity], offset, 0, layer), granularity, now);
+    }
+    return { windows, byModel, byLayer, byLayerStats, trend: { granularity, byLayer: trendByLayer } };
+}

--- a/dist/token-cost.js
+++ b/dist/token-cost.js
@@ -3,11 +3,15 @@ let db = null;
 export function initTokenCost(d) {
     db = d;
 }
-/** 记录一次蒸馏调用成本（callLLM 出口调用；model 由调用方传入）。 */
-export function recordCostCall(model, layer, inputChars, outputTokens, reasoningTokens) {
+/** 插件卸载时清空 db 引用（index.ts 的 ctx.effect 清理里调用，防悬空引用）。 */
+export function resetTokenCost() {
+    db = null;
+}
+/** 记录一次蒸馏调用成本（callLLM 出口调用；provider/model 由调用方传入）。 */
+export function recordCostCall(provider, model, layer, inputChars, outputTokens, reasoningTokens) {
     if (!db)
         return;
-    db.insertCostCall(model, layer, inputChars, outputTokens, reasoningTokens);
+    db.insertCostCall(provider, model, layer, inputChars, outputTokens, reasoningTokens);
 }
 /** 四窗口定义：range + 回看毫秒数（all 的 ms 恒 0）。 */
 const WINDOW_DEFS = [
@@ -33,6 +37,10 @@ function medianOf(sorted) {
     const mid = Math.floor(n / 2);
     return n % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
+/** provider/model 复合键（避免跨 provider 同名 model 在聚合里混淆）。 */
+function modelKey(provider, model) {
+    return provider + '/' + model;
+}
 /** 从某模型某粒度的 bucket 序列算均值/中位数（活跃桶口径：只除有调用的桶数）。 */
 function statOf(rows) {
     const active = rows.filter((r) => r.calls > 0);
@@ -46,23 +54,23 @@ function statOf(rows) {
         medianOutput: medianOf(active.map((r) => r.outputTokens).sort((a, b) => a - b)),
     };
 }
-/** 从 day/week/month 三组 bucket 行组装每个模型的统计指标。 */
+/** 从 day/week/month 三组 bucket 行组装每个模型的统计指标（provider/model 复合键）。 */
 function buildModelMetrics(dayRows, weekRows, monthRows) {
-    const models = new Set();
+    const keys = new Set();
     for (const r of dayRows)
-        models.add(r.model);
+        keys.add(modelKey(r.provider, r.model));
     for (const r of weekRows)
-        models.add(r.model);
+        keys.add(modelKey(r.provider, r.model));
     for (const r of monthRows)
-        models.add(r.model);
-    return Array.from(models)
+        keys.add(modelKey(r.provider, r.model));
+    return Array.from(keys)
         .sort()
-        .map((model) => {
-        const d = statOf(dayRows.filter((r) => r.model === model));
-        const w = statOf(weekRows.filter((r) => r.model === model));
-        const m = statOf(monthRows.filter((r) => r.model === model));
+        .map((key) => {
+        const d = statOf(dayRows.filter((r) => modelKey(r.provider, r.model) === key));
+        const w = statOf(weekRows.filter((r) => modelKey(r.provider, r.model) === key));
+        const m = statOf(monthRows.filter((r) => modelKey(r.provider, r.model) === key));
         return {
-            model,
+            model: key,
             dayCalls: d.avgCalls,
             weekCalls: w.avgCalls,
             monthCalls: m.avgCalls,
@@ -75,10 +83,9 @@ function buildModelMetrics(dayRows, weekRows, monthRows) {
         };
     });
 }
-/** 从某层级某粒度的 bucket 行生成连续趋势桶（空桶补 0）。 */
-function buildTrend(rows, granularity, now) {
+/** 从某层级某粒度的 bucket 行生成连续趋势桶（空桶补 0；count 为桶数，由调用方按展示范围算）。 */
+function buildTrend(rows, granularity, now, count) {
     const bucketMs = TREND_MS[granularity];
-    const count = TREND_COUNT[granularity];
     const offset = localOffsetMs();
     const cur = Math.floor((now + offset) / bucketMs);
     const buckets = [];
@@ -92,12 +99,13 @@ function buildTrend(rows, granularity, now) {
             continue;
         const tb = buckets[idx];
         tb.total += r.outputTokens;
-        tb.byModel[r.model] = (tb.byModel[r.model] ?? 0) + r.outputTokens;
+        const key = modelKey(r.provider, r.model);
+        tb.byModel[key] = (tb.byModel[key] ?? 0) + r.outputTokens;
     }
     return buckets;
 }
-/** 读成本看板快照（db 未注入/降级时返回全零结构，不抛错）。 */
-export function snapshotTokenCost(granularity) {
+/** 读成本看板快照（db 未注入/降级时返回全零结构，不抛错；rangeDays>0 = 趋势展示近 N 天）。 */
+export function snapshotTokenCost(granularity, rangeDays) {
     const now = Date.now();
     const emptyWindow = (range, ms) => ({
         range,
@@ -149,16 +157,19 @@ export function snapshotTokenCost(granularity) {
             };
         }),
     }));
-    // 每层级模型统计 + 趋势
+    // 每层级模型统计（全量历史口径）+ 趋势（按展示范围）
     const offset = localOffsetMs();
     const byLayerStats = [];
     const trendByLayer = { l1: [], l2: [], l3: [] };
+    // 趋势展示范围：rangeDays > 0 = 近 N 天（since + 桶数按 N 折算）；否则用默认窗口
+    const trendSince = rangeDays > 0 ? now - rangeDays * 24 * 3600_000 : 0;
+    const trendCount = rangeDays > 0 ? Math.max(1, Math.ceil((rangeDays * 24 * 3600_000) / TREND_MS[granularity])) : TREND_COUNT[granularity];
     for (const layer of LAYERS) {
         const dayRows = d.aggregateByBucket(TREND_MS.day, offset, 0, layer);
         const weekRows = d.aggregateByBucket(TREND_MS.week, offset, 0, layer);
         const monthRows = d.aggregateByBucket(TREND_MS.month, offset, 0, layer);
         byLayerStats.push({ layer, models: buildModelMetrics(dayRows, weekRows, monthRows) });
-        trendByLayer[layer] = buildTrend(d.aggregateByBucket(TREND_MS[granularity], offset, 0, layer), granularity, now);
+        trendByLayer[layer] = buildTrend(d.aggregateByBucket(TREND_MS[granularity], offset, trendSince, layer), granularity, now, trendCount);
     }
     return { windows, byModel, byLayer, byLayerStats, trend: { granularity, byLayer: trendByLayer } };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import type { MemoryLogger } from './types.js';
 import { errDetail, withFileLog } from './util/filelog.js';
 import { resolveModelRoute, invalidateEffortCache } from './llm.js';
 import { effectiveCfg } from './pipeline/runner.js';
+import { initTokenCost } from './token-cost.js';
 
 export const name = 'dsh-memory-plugin';
 
@@ -133,6 +134,7 @@ export async function apply(ctx: Context, config: MemoryConfig): Promise<void> {
   // ── 检索引擎（memory.db）与向量服务 ──
   const embed = initial.svc;
   const db = new MemoryDb(path.join(dataDir, 'memory.db'), initial.dims, logger);
+  initTokenCost(db);
   // 插件卸载时关闭连接（WAL 落盘），注册一次即可
   ctx.effect(() => () => db.close());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ import type { MemoryLogger } from './types.js';
 import { errDetail, withFileLog } from './util/filelog.js';
 import { resolveModelRoute, invalidateEffortCache } from './llm.js';
 import { effectiveCfg } from './pipeline/runner.js';
-import { initTokenCost } from './token-cost.js';
+import { initTokenCost, resetTokenCost } from './token-cost.js';
 
 export const name = 'dsh-memory-plugin';
 
@@ -379,6 +379,7 @@ export async function apply(ctx: Context, config: MemoryConfig): Promise<void> {
     return (async () => {
       await flushL0?.();
       db.close();
+      resetTokenCost();
     })();
   });
 }

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -275,14 +275,14 @@ export async function callLLM(ctx: Context, cfg: MemoryConfig, opts: LlmCallOpti
   } catch (err) {
     // 记账含失败路径（failures 计数；tokens 尽当时流内已到的 usage）
     if (opts.layer) recordDistillCall(opts.layer, user.length, outputTokens, reasoningTokens, true);
-    if (opts.layer) recordCostCall(model, opts.layer, user.length, outputTokens, reasoningTokens);
+    if (opts.layer) recordCostCall(provider, model, opts.layer, user.length, outputTokens, reasoningTokens);
     opts.logger?.warn(
       `[memory] LLM 调用失败 ${provider}/${model}（${((Date.now() - startedAt) / 1000).toFixed(1)}s）: ${errDetail(err)}`,
     );
     throw err;
   }
   if (opts.layer) recordDistillCall(opts.layer, user.length, outputTokens, reasoningTokens, false);
-  if (opts.layer) recordCostCall(model, opts.layer, user.length, outputTokens, reasoningTokens);
+  if (opts.layer) recordCostCall(provider, model, opts.layer, user.length, outputTokens, reasoningTokens);
   const out = (blockText || deltaText).trim();
   if (out.length === 0) {
     // 空输出是最难排查的失败：流正常结束但一个字没吐。必须记录 finish 原因、

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -9,6 +9,7 @@ import type { MemoryConfig } from './config.js';
 import type { MemoryLogger } from './types.js';
 import { errDetail } from './util/filelog.js';
 import { recordDistillCall, type DistillLayer } from './llm-usage.js';
+import { recordCostCall } from './token-cost.js';
 
 export interface LlmCallOptions {
   system: string;
@@ -274,12 +275,14 @@ export async function callLLM(ctx: Context, cfg: MemoryConfig, opts: LlmCallOpti
   } catch (err) {
     // 记账含失败路径（failures 计数；tokens 尽当时流内已到的 usage）
     if (opts.layer) recordDistillCall(opts.layer, user.length, outputTokens, reasoningTokens, true);
+    if (opts.layer) recordCostCall(model, opts.layer, user.length, outputTokens, reasoningTokens);
     opts.logger?.warn(
       `[memory] LLM 调用失败 ${provider}/${model}（${((Date.now() - startedAt) / 1000).toFixed(1)}s）: ${errDetail(err)}`,
     );
     throw err;
   }
   if (opts.layer) recordDistillCall(opts.layer, user.length, outputTokens, reasoningTokens, false);
+  if (opts.layer) recordCostCall(model, opts.layer, user.length, outputTokens, reasoningTokens);
   const out = (blockText || deltaText).trim();
   if (out.length === 0) {
     // 空输出是最难排查的失败：流正常结束但一个字没吐。必须记录 finish 原因、

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -31,6 +31,7 @@ import type { EmbeddingManager } from './store/embedding-source.js';
 import type { StateStore } from './store/state.js';
 import type { MemoryFamily, MemoryLogger, MemoryMode } from './types.js';
 import { errDetail } from './util/filelog.js';
+import { snapshotTokenCost } from './token-cost.js';
 
 const require = createRequire(import.meta.url);
 export const PLUGIN_VERSION = (require('../package.json') as { version: string }).version;
@@ -274,6 +275,13 @@ async function handleEndpoint(endpoint: string, payload: unknown, deps: Endpoint
   switch (endpoint) {
     case 'dsh-memory/stats':
       return buildStats(cfg, stores, status);
+
+    case 'dsh-memory/token-cost': {
+      const p = (payload ?? {}) as { granularity?: string };
+      const granularity: 'day' | 'week' | 'month' =
+        p.granularity === 'week' || p.granularity === 'month' ? p.granularity : 'day';
+      return snapshotTokenCost(granularity);
+    }
 
     case 'dsh-memory/session-mode-get': {
       if (!modes) throw new Error('档位存储未初始化');

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -277,10 +277,13 @@ async function handleEndpoint(endpoint: string, payload: unknown, deps: Endpoint
       return buildStats(cfg, stores, status);
 
     case 'dsh-memory/token-cost': {
-      const p = (payload ?? {}) as { granularity?: string };
+      const p = (payload ?? {}) as { granularity?: string; rangeDays?: number };
       const granularity: 'day' | 'week' | 'month' =
         p.granularity === 'week' || p.granularity === 'month' ? p.granularity : 'day';
-      return snapshotTokenCost(granularity);
+      // rangeDays 须为 1~365 的正整数（存储上限 365 天），否则回退默认窗口
+      const rawDays = p.rangeDays;
+      const rangeDays = typeof rawDays === 'number' && Number.isInteger(rawDays) && rawDays > 0 && rawDays <= 365 ? rawDays : 0;
+      return snapshotTokenCost(granularity, rangeDays);
     }
 
     case 'dsh-memory/session-mode-get': {

--- a/src/store/sqlite.ts
+++ b/src/store/sqlite.ts
@@ -53,6 +53,7 @@ export interface CostAggregate {
 
 /** 按 model 分组的成本行（成本看板用）。 */
 export interface CostByModel {
+  provider: string;
   model: string;
   calls: number;
   inputChars: number;
@@ -71,9 +72,10 @@ export interface CostByLayer {
   medianOutputTokens: number;
 }
 
-/** 按时间桶 + model 聚合的扁平行（趋势图与日均/周均/月均 + 中位数统计共用）。 */
+/** 按时间桶 + provider/model 聚合的扁平行（趋势图与日均/周均/月均 + 中位数统计共用）。 */
 export interface BucketRow {
   bucket: number;
+  provider: string;
   model: string;
   calls: number;
   outputTokens: number;
@@ -158,6 +160,9 @@ export class MemoryDb {
   private stmtL1FtsDelete!: StatementLike;
   private stmtL1FtsSearch!: StatementLike;
   private stmtL1FtsSearchFamily!: StatementLike;
+  /** token_cost 明细写入 / 滚动清理语句（构造期 prepare 缓存）。 */
+  private stmtInsertCost!: StatementLike;
+  private stmtDeleteCost!: StatementLike;
 
   private stmtUpsertL0!: StatementLike;
   private stmtGetL0!: StatementLike;
@@ -437,6 +442,7 @@ export class MemoryDb {
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS token_cost (
         ts INTEGER NOT NULL,
+        provider TEXT NOT NULL,
         model TEXT NOT NULL,
         layer TEXT NOT NULL,
         input_chars INTEGER NOT NULL DEFAULT 0,
@@ -444,7 +450,15 @@ export class MemoryDb {
         reasoning_tokens INTEGER NOT NULL DEFAULT 0
       )
     `);
+    // 迁移：provider/model 复合键引入前的旧表补 provider 列（历史行回填 unknown）
+    if (this.tableExists('token_cost') && !this.hasColumn('token_cost', 'provider')) {
+      this.db.exec("ALTER TABLE token_cost ADD COLUMN provider TEXT NOT NULL DEFAULT 'unknown'");
+    }
     this.db.exec('CREATE INDEX IF NOT EXISTS idx_token_cost_ts ON token_cost(ts)');
+    this.stmtInsertCost = this.db.prepare(
+      'INSERT INTO token_cost (ts, provider, model, layer, input_chars, output_tokens, reasoning_tokens) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    );
+    this.stmtDeleteCost = this.db.prepare('DELETE FROM token_cost WHERE ts < ?');
 
 
     // ── FTS5 全文索引（建表失败仅停用 FTS，不降级整个库） ──
@@ -1168,17 +1182,23 @@ export class MemoryDb {
 
   /**
    * 记录一次蒸馏调用成本（明细表，365 天滚动清理）。
-   * 失败/成功都记（token 照烧）；记账失败不阻断蒸馏（成本看板是增强能力）。
+   * 失败/成功都记（token 照烧）；记账失败记 warn 但不阻断蒸馏（成本看板是增强能力）。
    */
-  insertCostCall(model: string, layer: string, inputChars: number, outputTokens: number, reasoningTokens: number): void {
+  insertCostCall(provider: string, model: string, layer: string, inputChars: number, outputTokens: number, reasoningTokens: number): void {
     if (this.degraded) return;
     try {
-      this.db.prepare(
-        'INSERT INTO token_cost (ts, model, layer, input_chars, output_tokens, reasoning_tokens) VALUES (?, ?, ?, ?, ?, ?)',
-      ).run(Date.now(), model, layer, Math.max(0, Math.round(inputChars)), Math.max(0, Math.round(outputTokens)), Math.max(0, Math.round(reasoningTokens)));
-      this.db.prepare('DELETE FROM token_cost WHERE ts < ?').run(Date.now() - 365 * 24 * 3600_000);
-    } catch {
-      /* 记账失败不阻断蒸馏 */
+      this.stmtInsertCost.run(
+        Date.now(),
+        provider,
+        model,
+        layer,
+        Math.max(0, Math.round(inputChars)),
+        Math.max(0, Math.round(outputTokens)),
+        Math.max(0, Math.round(reasoningTokens)),
+      );
+      this.stmtDeleteCost.run(Date.now() - 365 * 24 * 3600_000);
+    } catch (err) {
+      this.logger?.warn(`${TAG} token_cost 记账失败: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
@@ -1212,11 +1232,11 @@ export class MemoryDb {
         .all(since) as Array<{ output_tokens: number }>;
       const byModel = this.db
         .prepare(
-          `SELECT model, COUNT(*) AS calls,
+          `SELECT provider, model, COUNT(*) AS calls,
                   COALESCE(SUM(input_chars), 0) AS inputChars,
                   COALESCE(SUM(output_tokens), 0) AS outputTokens,
                   COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens
-             FROM token_cost WHERE ts >= ? GROUP BY model ORDER BY outputTokens DESC`,
+             FROM token_cost WHERE ts >= ? GROUP BY provider, model ORDER BY outputTokens DESC`,
         )
         .all(since) as unknown as CostByModel[];
       return {
@@ -1292,7 +1312,7 @@ export class MemoryDb {
     if (this.degraded) return [];
     try {
       let sql =
-        `SELECT CAST((ts + ?) / ? AS INTEGER) AS bucket, model,
+        `SELECT CAST((ts + ?) / ? AS INTEGER) AS bucket, provider, model,
                 COUNT(*) AS calls,
                 COALESCE(SUM(output_tokens), 0) AS outputTokens,
                 COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens
@@ -1304,7 +1324,7 @@ export class MemoryDb {
         sql += ` AND layer = ?`;
         params.push(layer);
       }
-      sql += ` GROUP BY bucket, model ORDER BY bucket, model`;
+      sql += ` GROUP BY bucket, provider, model ORDER BY bucket, provider, model`;
       return this.db.prepare(sql).all(...params) as unknown as BucketRow[];
     } catch {
       return [];

--- a/src/store/sqlite.ts
+++ b/src/store/sqlite.ts
@@ -39,6 +39,47 @@ export interface StoreCapabilities {
   vectorSearch: boolean;
 }
 
+/** token_cost 单窗口成本聚合（成本看板用）。 */
+export interface CostAggregate {
+  calls: number;
+  inputChars: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  /** 单次调用输出 token 均值（无数据为 0）。 */
+  avgOutputTokens: number;
+  /** 单次调用输出 token 中位数（无数据为 0）。 */
+  medianOutputTokens: number;
+}
+
+/** 按 model 分组的成本行（成本看板用）。 */
+export interface CostByModel {
+  model: string;
+  calls: number;
+  inputChars: number;
+  outputTokens: number;
+  reasoningTokens: number;
+}
+
+/** 按层级（l1/l2/l3 归并）分组的成本行。 */
+export interface CostByLayer {
+  layer: string;
+  calls: number;
+  inputChars: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  avgOutputTokens: number;
+  medianOutputTokens: number;
+}
+
+/** 按时间桶 + model 聚合的扁平行（趋势图与日均/周均/月均 + 中位数统计共用）。 */
+export interface BucketRow {
+  bucket: number;
+  model: string;
+  calls: number;
+  outputTokens: number;
+  reasoningTokens: number;
+}
+
 /** L1 检索命中（含 BM25/余弦归一分数）。 */
 export interface L1SearchHit {
   id: string;
@@ -81,6 +122,18 @@ function chunkIds(ids: string[]): string[][] {
   const out: string[][] = [];
   for (let i = 0; i < ids.length; i += IN_CHUNK) out.push(ids.slice(i, i + IN_CHUNK));
   return out;
+}
+
+function emptyCostAggregate(): CostAggregate {
+  return { calls: 0, inputChars: 0, outputTokens: 0, reasoningTokens: 0, avgOutputTokens: 0, medianOutputTokens: 0 };
+}
+
+/** 已排序序列的中位数（偶数个取中间两者平均；空返回 0）。 */
+function medianOf(sorted: number[]): number {
+  const n = sorted.length;
+  if (n === 0) return 0;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
 export class MemoryDb {
@@ -380,6 +433,19 @@ export class MemoryDb {
     );
     this.stmtL0Exists = this.db.prepare('SELECT 1 FROM l0_conversations WHERE record_id = ?');
     this.prepareL0VecStatements();
+    // ── token_cost：蒸馏成本明细表（成本看板用；365 天滚动清理） ──
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS token_cost (
+        ts INTEGER NOT NULL,
+        model TEXT NOT NULL,
+        layer TEXT NOT NULL,
+        input_chars INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        reasoning_tokens INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+    this.db.exec('CREATE INDEX IF NOT EXISTS idx_token_cost_ts ON token_cost(ts)');
+
 
     // ── FTS5 全文索引（建表失败仅停用 FTS，不降级整个库） ──
     try {
@@ -1083,6 +1149,151 @@ export class MemoryDb {
       }
       this.logger?.warn(`${TAG} L0 批量写入失败: ${err instanceof Error ? err.message : String(err)}`);
       return false;
+    }
+  }
+
+  /**
+   * 记录一次蒸馏调用成本（明细表，365 天滚动清理）。
+   * 失败/成功都记（token 照烧）；记账失败不阻断蒸馏（成本看板是增强能力）。
+   */
+  insertCostCall(model: string, layer: string, inputChars: number, outputTokens: number, reasoningTokens: number): void {
+    if (this.degraded) return;
+    try {
+      this.db.prepare(
+        'INSERT INTO token_cost (ts, model, layer, input_chars, output_tokens, reasoning_tokens) VALUES (?, ?, ?, ?, ?, ?)',
+      ).run(Date.now(), model, layer, Math.max(0, Math.round(inputChars)), Math.max(0, Math.round(outputTokens)), Math.max(0, Math.round(reasoningTokens)));
+      this.db.prepare('DELETE FROM token_cost WHERE ts < ?').run(Date.now() - 365 * 24 * 3600_000);
+    } catch {
+      /* 记账失败不阻断蒸馏 */
+    }
+  }
+
+  /**
+   * 查询 token_cost 单窗口聚合（成本看板用；since 为毫秒起点，0 = 全量）。
+   * 输入口径：inputChars 是字符（llm 流拿不到输入 token，沿用 llm-usage 的字符折算口径）。
+   * 成本看板是增强能力：降级态/查询异常一律返回零值，不向上抛错。
+   * median 需取 output_tokens 序列在 JS 侧算（SQLite 无内置 median 函数）。
+   */
+  aggregateCost(since: number): { total: CostAggregate; byModel: CostByModel[] } {
+    if (this.degraded) return { total: emptyCostAggregate(), byModel: [] };
+    try {
+      const total = this.db
+        .prepare(
+          `SELECT COUNT(*) AS calls,
+                  COALESCE(SUM(input_chars), 0) AS inputChars,
+                  COALESCE(SUM(output_tokens), 0) AS outputTokens,
+                  COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens,
+                  COALESCE(AVG(output_tokens), 0) AS avgOutputTokens
+             FROM token_cost WHERE ts >= ?`,
+        )
+        .get(since) as {
+        calls: number;
+        inputChars: number;
+        outputTokens: number;
+        reasoningTokens: number;
+        avgOutputTokens: number;
+      };
+      const tokenRows = this.db
+        .prepare('SELECT output_tokens FROM token_cost WHERE ts >= ? ORDER BY output_tokens')
+        .all(since) as Array<{ output_tokens: number }>;
+      const byModel = this.db
+        .prepare(
+          `SELECT model, COUNT(*) AS calls,
+                  COALESCE(SUM(input_chars), 0) AS inputChars,
+                  COALESCE(SUM(output_tokens), 0) AS outputTokens,
+                  COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens
+             FROM token_cost WHERE ts >= ? GROUP BY model ORDER BY outputTokens DESC`,
+        )
+        .all(since) as unknown as CostByModel[];
+      return {
+        total: {
+          calls: total.calls,
+          inputChars: total.inputChars,
+          outputTokens: total.outputTokens,
+          reasoningTokens: total.reasoningTokens,
+          avgOutputTokens: total.avgOutputTokens,
+          medianOutputTokens: medianOf(tokenRows.map((r) => r.output_tokens)),
+        },
+        byModel,
+      };
+    } catch {
+      return { total: emptyCostAggregate(), byModel: [] };
+    }
+  }
+
+  /**
+   * 按层级归并聚合（l1 = l1-extract + l1-dedup；成本看板层级表格用）。
+   * 降级/异常返回空数组，不抛错。
+   */
+  aggregateCostByLayer(since: number): CostByLayer[] {
+    if (this.degraded) return [];
+    try {
+      const rows = this.db
+        .prepare(
+          `SELECT CASE WHEN layer IN ('l1-extract','l1-dedup') THEN 'l1' ELSE layer END AS layer,
+                  COUNT(*) AS calls,
+                  COALESCE(SUM(input_chars), 0) AS inputChars,
+                  COALESCE(SUM(output_tokens), 0) AS outputTokens,
+                  COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens,
+                  COALESCE(AVG(output_tokens), 0) AS avgOutputTokens
+             FROM token_cost WHERE ts >= ? GROUP BY layer ORDER BY layer`,
+        )
+        .all(since) as unknown as Array<{
+        layer: string;
+        calls: number;
+        inputChars: number;
+        outputTokens: number;
+        reasoningTokens: number;
+        avgOutputTokens: number;
+      }>;
+      // 中位数需取 output_tokens 序列在 JS 侧算（SQLite 无内置 median）
+      const tokenRows = this.db
+        .prepare(
+          `SELECT CASE WHEN layer IN ('l1-extract','l1-dedup') THEN 'l1' ELSE layer END AS layer,
+                  output_tokens
+             FROM token_cost WHERE ts >= ? ORDER BY layer, output_tokens`,
+        )
+        .all(since) as unknown as Array<{ layer: string; output_tokens: number }>;
+      const medianByLayer = new Map<string, number[]>();
+      for (const r of tokenRows) {
+        const arr = medianByLayer.get(r.layer);
+        if (arr) arr.push(r.output_tokens);
+        else medianByLayer.set(r.layer, [r.output_tokens]);
+      }
+      return rows.map((r) => ({
+        ...r,
+        medianOutputTokens: medianOf(medianByLayer.get(r.layer) ?? []),
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * 按时间桶（bucketMs 毫秒）+ model 聚合，返回扁平行。
+   * offsetMs 把桶边界对齐本地时区；layer 为空=全部，'l1' 归并 extract/dedup，其余精确匹配。
+   * 趋势图与「日均/周均/月均 + 中位数」统计共用：JS 侧按不同 bucketMs 调三次再聚合。
+   */
+  aggregateByBucket(bucketMs: number, offsetMs: number, since: number, layer: string): BucketRow[] {
+    if (this.degraded) return [];
+    try {
+      let sql =
+        `SELECT CAST((ts + ?) / ? AS INTEGER) AS bucket, model,
+                COUNT(*) AS calls,
+                COALESCE(SUM(output_tokens), 0) AS outputTokens,
+                COALESCE(SUM(reasoning_tokens), 0) AS reasoningTokens
+           FROM token_cost WHERE ts >= ?`;
+      const params: Array<string | number> = [offsetMs, bucketMs, since];
+      if (layer === 'l1') {
+        sql += ` AND layer IN ('l1-extract','l1-dedup')`;
+      } else if (layer) {
+        sql += ` AND layer = ?`;
+        params.push(layer);
+      }
+      sql += ` GROUP BY bucket, model ORDER BY bucket, model`;
+      return this.db.prepare(sql).all(...params) as unknown as BucketRow[];
+    } catch {
+      return [];
     }
   }
 

--- a/src/token-cost.ts
+++ b/src/token-cost.ts
@@ -265,16 +265,16 @@ export function snapshotTokenCost(granularity: Granularity, rangeDays: number): 
   const offset = localOffsetMs();
   const byLayerStats: LayerMetrics[] = [];
   const trendByLayer: Record<'l1' | 'l2' | 'l3', TrendBucket[]> = { l1: [], l2: [], l3: [] };
-  // 趋势展示范围：rangeDays > 0 = 近 N 天（since + 桶数按 N 折算）；否则用默认窗口
+  // 趋势展示范围：rangeDays > 0 = 近 N 天（强制按「日」粒度出 N 个日桶，不受周/月聚合影响）；否则用默认窗口
+  const trendGranularity: Granularity = rangeDays > 0 ? 'day' : granularity;
   const trendSince = rangeDays > 0 ? now - rangeDays * 24 * 3600_000 : 0;
-  const trendCount =
-    rangeDays > 0 ? Math.max(1, Math.ceil((rangeDays * 24 * 3600_000) / TREND_MS[granularity])) : TREND_COUNT[granularity];
+  const trendCount = rangeDays > 0 ? rangeDays : TREND_COUNT[granularity];
   for (const layer of LAYERS) {
     const dayRows = d.aggregateByBucket(TREND_MS.day, offset, 0, layer);
     const weekRows = d.aggregateByBucket(TREND_MS.week, offset, 0, layer);
     const monthRows = d.aggregateByBucket(TREND_MS.month, offset, 0, layer);
     byLayerStats.push({ layer, models: buildModelMetrics(dayRows, weekRows, monthRows) });
-    trendByLayer[layer] = buildTrend(d.aggregateByBucket(TREND_MS[granularity], offset, trendSince, layer), granularity, now, trendCount);
+    trendByLayer[layer] = buildTrend(d.aggregateByBucket(TREND_MS[trendGranularity], offset, trendSince, layer), trendGranularity, now, trendCount);
   }
-  return { windows, byModel, byLayer, byLayerStats, trend: { granularity, byLayer: trendByLayer } };
+  return { windows, byModel, byLayer, byLayerStats, trend: { granularity: trendGranularity, byLayer: trendByLayer } };
 }

--- a/src/token-cost.ts
+++ b/src/token-cost.ts
@@ -17,8 +17,14 @@ export function initTokenCost(d: MemoryDb): void {
   db = d;
 }
 
-/** 记录一次蒸馏调用成本（callLLM 出口调用；model 由调用方传入）。 */
+/** 插件卸载时清空 db 引用（index.ts 的 ctx.effect 清理里调用，防悬空引用）。 */
+export function resetTokenCost(): void {
+  db = null;
+}
+
+/** 记录一次蒸馏调用成本（callLLM 出口调用；provider/model 由调用方传入）。 */
 export function recordCostCall(
+  provider: string,
   model: string,
   layer: DistillLayer,
   inputChars: number,
@@ -26,7 +32,7 @@ export function recordCostCall(
   reasoningTokens: number,
 ): void {
   if (!db) return;
-  db.insertCostCall(model, layer, inputChars, outputTokens, reasoningTokens);
+  db.insertCostCall(provider, model, layer, inputChars, outputTokens, reasoningTokens);
 }
 
 /** 成本看板单个时间窗口（day/week/month/all）。 */
@@ -45,7 +51,7 @@ export interface CostWindow {
 /** 成本看板时间粒度（趋势图 + 统计口径共用）。 */
 export type Granularity = 'day' | 'week' | 'month';
 
-/** 每模型统计指标（层级表格行；均值按活跃桶口径，中位数按活跃桶序列）。 */
+/** 每模型统计指标（层级表格行；均值/中位数按 since=0 全量历史的活跃桶口径，非「最近窗口」）。 */
 export interface ModelMetrics {
   model: string;
   dayCalls: number;
@@ -137,6 +143,11 @@ function medianOf(sorted: number[]): number {
   return n % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
+/** provider/model 复合键（避免跨 provider 同名 model 在聚合里混淆）。 */
+function modelKey(provider: string, model: string): string {
+  return provider + '/' + model;
+}
+
 /** 从某模型某粒度的 bucket 序列算均值/中位数（活跃桶口径：只除有调用的桶数）。 */
 function statOf(rows: BucketRow[]): { avgCalls: number; avgOutput: number; medianOutput: number } {
   const active = rows.filter((r) => r.calls > 0);
@@ -150,20 +161,20 @@ function statOf(rows: BucketRow[]): { avgCalls: number; avgOutput: number; media
   };
 }
 
-/** 从 day/week/month 三组 bucket 行组装每个模型的统计指标。 */
+/** 从 day/week/month 三组 bucket 行组装每个模型的统计指标（provider/model 复合键）。 */
 function buildModelMetrics(dayRows: BucketRow[], weekRows: BucketRow[], monthRows: BucketRow[]): ModelMetrics[] {
-  const models = new Set<string>();
-  for (const r of dayRows) models.add(r.model);
-  for (const r of weekRows) models.add(r.model);
-  for (const r of monthRows) models.add(r.model);
-  return Array.from(models)
+  const keys = new Set<string>();
+  for (const r of dayRows) keys.add(modelKey(r.provider, r.model));
+  for (const r of weekRows) keys.add(modelKey(r.provider, r.model));
+  for (const r of monthRows) keys.add(modelKey(r.provider, r.model));
+  return Array.from(keys)
     .sort()
-    .map((model) => {
-      const d = statOf(dayRows.filter((r) => r.model === model));
-      const w = statOf(weekRows.filter((r) => r.model === model));
-      const m = statOf(monthRows.filter((r) => r.model === model));
+    .map((key) => {
+      const d = statOf(dayRows.filter((r) => modelKey(r.provider, r.model) === key));
+      const w = statOf(weekRows.filter((r) => modelKey(r.provider, r.model) === key));
+      const m = statOf(monthRows.filter((r) => modelKey(r.provider, r.model) === key));
       return {
-        model,
+        model: key,
         dayCalls: d.avgCalls,
         weekCalls: w.avgCalls,
         monthCalls: m.avgCalls,
@@ -177,10 +188,9 @@ function buildModelMetrics(dayRows: BucketRow[], weekRows: BucketRow[], monthRow
     });
 }
 
-/** 从某层级某粒度的 bucket 行生成连续趋势桶（空桶补 0）。 */
-function buildTrend(rows: BucketRow[], granularity: Granularity, now: number): TrendBucket[] {
+/** 从某层级某粒度的 bucket 行生成连续趋势桶（空桶补 0；count 为桶数，由调用方按展示范围算）。 */
+function buildTrend(rows: BucketRow[], granularity: Granularity, now: number, count: number): TrendBucket[] {
   const bucketMs = TREND_MS[granularity];
-  const count = TREND_COUNT[granularity];
   const offset = localOffsetMs();
   const cur = Math.floor((now + offset) / bucketMs);
   const buckets: TrendBucket[] = [];
@@ -193,13 +203,14 @@ function buildTrend(rows: BucketRow[], granularity: Granularity, now: number): T
     if (idx < 0 || idx >= count) continue;
     const tb = buckets[idx];
     tb.total += r.outputTokens;
-    tb.byModel[r.model] = (tb.byModel[r.model] ?? 0) + r.outputTokens;
+    const key = modelKey(r.provider, r.model);
+    tb.byModel[key] = (tb.byModel[key] ?? 0) + r.outputTokens;
   }
   return buckets;
 }
 
-/** 读成本看板快照（db 未注入/降级时返回全零结构，不抛错）。 */
-export function snapshotTokenCost(granularity: Granularity): CostSnapshot {
+/** 读成本看板快照（db 未注入/降级时返回全零结构，不抛错；rangeDays>0 = 趋势展示近 N 天）。 */
+export function snapshotTokenCost(granularity: Granularity, rangeDays: number): CostSnapshot {
   const now = Date.now();
   const emptyWindow = (range: CostWindow['range'], ms: number): CostWindow => ({
     range,
@@ -250,16 +261,20 @@ export function snapshotTokenCost(granularity: Granularity): CostSnapshot {
       };
     }),
   }));
-  // 每层级模型统计 + 趋势
+  // 每层级模型统计（全量历史口径）+ 趋势（按展示范围）
   const offset = localOffsetMs();
   const byLayerStats: LayerMetrics[] = [];
   const trendByLayer: Record<'l1' | 'l2' | 'l3', TrendBucket[]> = { l1: [], l2: [], l3: [] };
+  // 趋势展示范围：rangeDays > 0 = 近 N 天（since + 桶数按 N 折算）；否则用默认窗口
+  const trendSince = rangeDays > 0 ? now - rangeDays * 24 * 3600_000 : 0;
+  const trendCount =
+    rangeDays > 0 ? Math.max(1, Math.ceil((rangeDays * 24 * 3600_000) / TREND_MS[granularity])) : TREND_COUNT[granularity];
   for (const layer of LAYERS) {
     const dayRows = d.aggregateByBucket(TREND_MS.day, offset, 0, layer);
     const weekRows = d.aggregateByBucket(TREND_MS.week, offset, 0, layer);
     const monthRows = d.aggregateByBucket(TREND_MS.month, offset, 0, layer);
     byLayerStats.push({ layer, models: buildModelMetrics(dayRows, weekRows, monthRows) });
-    trendByLayer[layer] = buildTrend(d.aggregateByBucket(TREND_MS[granularity], offset, 0, layer), granularity, now);
+    trendByLayer[layer] = buildTrend(d.aggregateByBucket(TREND_MS[granularity], offset, trendSince, layer), granularity, now, trendCount);
   }
   return { windows, byModel, byLayer, byLayerStats, trend: { granularity, byLayer: trendByLayer } };
 }

--- a/src/token-cost.ts
+++ b/src/token-cost.ts
@@ -1,0 +1,265 @@
+/**
+ * 蒸馏成本看板账本：把每次蒸馏调用（model × layer）的 token 成本写入 SQLite 明细表。
+ *
+ * 模块级单例 + init 注入 db：callLLM 拿不到 db（db 在 index.ts 运行时创建），
+ * 故通过 initTokenCost(db) 在插件启动时注入；recordCostCall 每次调用写一行明细。
+ *
+ * 与作者 llm-usage.ts 的关系：作者是"按 layer 累计的纯内存计数器"（给 bench 用）；
+ * 本模块补上三个缺口——按 model 分组、持久化（365 天明细）、面向 UI 成本看板。
+ */
+import type { DistillLayer } from './llm-usage.js';
+import type { BucketRow, CostByModel, MemoryDb } from './store/sqlite.js';
+
+let db: MemoryDb | null = null;
+
+/** 插件启动时注入 db（index.ts 调用）。 */
+export function initTokenCost(d: MemoryDb): void {
+  db = d;
+}
+
+/** 记录一次蒸馏调用成本（callLLM 出口调用；model 由调用方传入）。 */
+export function recordCostCall(
+  model: string,
+  layer: DistillLayer,
+  inputChars: number,
+  outputTokens: number,
+  reasoningTokens: number,
+): void {
+  if (!db) return;
+  db.insertCostCall(model, layer, inputChars, outputTokens, reasoningTokens);
+}
+
+/** 成本看板单个时间窗口（day/week/month/all）。 */
+export interface CostWindow {
+  range: 'day' | 'week' | 'month' | 'all';
+  /** 窗口起点（毫秒；all 为 0）。 */
+  since: number;
+  calls: number;
+  inputChars: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  avgOutputTokens: number;
+  medianOutputTokens: number;
+}
+
+/** 成本看板时间粒度（趋势图 + 统计口径共用）。 */
+export type Granularity = 'day' | 'week' | 'month';
+
+/** 每模型统计指标（层级表格行；均值按活跃桶口径，中位数按活跃桶序列）。 */
+export interface ModelMetrics {
+  model: string;
+  dayCalls: number;
+  weekCalls: number;
+  monthCalls: number;
+  dayOutput: number;
+  dayMedian: number;
+  weekOutput: number;
+  weekMedian: number;
+  monthOutput: number;
+  monthMedian: number;
+}
+
+/** 每层级（l1/l2/l3）的模型统计（层级表格）。 */
+export interface LayerMetrics {
+  layer: 'l1' | 'l2' | 'l3';
+  models: ModelMetrics[];
+}
+
+/** 层级 × 窗口矩阵里的单个窗口格子。 */
+export interface LayerWindow {
+  range: 'day' | 'week' | 'month' | 'all';
+  calls: number;
+  inputChars: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  avgOutputTokens: number;
+  medianOutputTokens: number;
+}
+
+/** 单个层级在四个窗口的聚合（层级×窗口表格行）。 */
+export interface LayerCost {
+  layer: 'l1' | 'l2' | 'l3';
+  windows: LayerWindow[];
+}
+
+/** 趋势单桶。 */
+export interface TrendBucket {
+  ts: number;
+  total: number;
+  byModel: Record<string, number>;
+}
+
+/** 趋势快照：三个层级各一份连续桶序列。 */
+export interface TrendSnapshot {
+  granularity: Granularity;
+  byLayer: Record<'l1' | 'l2' | 'l3', TrendBucket[]>;
+}
+
+/** 成本看板快照（dsh-memory/token-cost 端点返回值）。 */
+export interface CostSnapshot {
+  /** day/week/month/all 四窗口聚合。 */
+  windows: CostWindow[];
+  /** 全量窗口（all）按 model 分组。 */
+  byModel: CostByModel[];
+  /** 按层级（l1/l2/l3 归并）在四个窗口的聚合（层级×窗口表格）。 */
+  byLayer: LayerCost[];
+  /** 每层级的模型统计指标（层级表格）。 */
+  byLayerStats: LayerMetrics[];
+  /** 趋势图数据。 */
+  trend: TrendSnapshot;
+}
+
+/** 四窗口定义：range + 回看毫秒数（all 的 ms 恒 0）。 */
+const WINDOW_DEFS: ReadonlyArray<{ range: CostWindow['range']; ms: number }> = [
+  { range: 'day', ms: 24 * 3600_000 },
+  { range: 'week', ms: 7 * 24 * 3600_000 },
+  { range: 'month', ms: 30 * 24 * 3600_000 },
+  { range: 'all', ms: 0 },
+];
+
+/** 趋势桶宽（毫秒）与桶数。 */
+const TREND_MS: Record<Granularity, number> = { day: 24 * 3600_000, week: 7 * 24 * 3600_000, month: 30 * 24 * 3600_000 };
+const TREND_COUNT: Record<Granularity, number> = { day: 30, week: 12, month: 12 };
+
+/** 三个归并层级。 */
+const LAYERS: ReadonlyArray<'l1' | 'l2' | 'l3'> = ['l1', 'l2', 'l3'];
+
+/** 本地时区偏移（东正西负）：把 SQL 端 UTC epoch 桶边界对齐到本地午夜。 */
+function localOffsetMs(): number {
+  return -new Date().getTimezoneOffset() * 60_000;
+}
+
+/** 已排序序列的中位数（偶数取中间两者平均；空返回 0）。 */
+function medianOf(sorted: number[]): number {
+  const n = sorted.length;
+  if (n === 0) return 0;
+  const mid = Math.floor(n / 2);
+  return n % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/** 从某模型某粒度的 bucket 序列算均值/中位数（活跃桶口径：只除有调用的桶数）。 */
+function statOf(rows: BucketRow[]): { avgCalls: number; avgOutput: number; medianOutput: number } {
+  const active = rows.filter((r) => r.calls > 0);
+  if (active.length === 0) return { avgCalls: 0, avgOutput: 0, medianOutput: 0 };
+  const calls = active.reduce((s, r) => s + r.calls, 0);
+  const output = active.reduce((s, r) => s + r.outputTokens, 0);
+  return {
+    avgCalls: calls / active.length,
+    avgOutput: output / active.length,
+    medianOutput: medianOf(active.map((r) => r.outputTokens).sort((a, b) => a - b)),
+  };
+}
+
+/** 从 day/week/month 三组 bucket 行组装每个模型的统计指标。 */
+function buildModelMetrics(dayRows: BucketRow[], weekRows: BucketRow[], monthRows: BucketRow[]): ModelMetrics[] {
+  const models = new Set<string>();
+  for (const r of dayRows) models.add(r.model);
+  for (const r of weekRows) models.add(r.model);
+  for (const r of monthRows) models.add(r.model);
+  return Array.from(models)
+    .sort()
+    .map((model) => {
+      const d = statOf(dayRows.filter((r) => r.model === model));
+      const w = statOf(weekRows.filter((r) => r.model === model));
+      const m = statOf(monthRows.filter((r) => r.model === model));
+      return {
+        model,
+        dayCalls: d.avgCalls,
+        weekCalls: w.avgCalls,
+        monthCalls: m.avgCalls,
+        dayOutput: d.avgOutput,
+        dayMedian: d.medianOutput,
+        weekOutput: w.avgOutput,
+        weekMedian: w.medianOutput,
+        monthOutput: m.avgOutput,
+        monthMedian: m.medianOutput,
+      };
+    });
+}
+
+/** 从某层级某粒度的 bucket 行生成连续趋势桶（空桶补 0）。 */
+function buildTrend(rows: BucketRow[], granularity: Granularity, now: number): TrendBucket[] {
+  const bucketMs = TREND_MS[granularity];
+  const count = TREND_COUNT[granularity];
+  const offset = localOffsetMs();
+  const cur = Math.floor((now + offset) / bucketMs);
+  const buckets: TrendBucket[] = [];
+  for (let i = count - 1; i >= 0; i--) {
+    const b = cur - i;
+    buckets.push({ ts: b * bucketMs - offset, total: 0, byModel: {} });
+  }
+  for (const r of rows) {
+    const idx = count - 1 - (cur - r.bucket);
+    if (idx < 0 || idx >= count) continue;
+    const tb = buckets[idx];
+    tb.total += r.outputTokens;
+    tb.byModel[r.model] = (tb.byModel[r.model] ?? 0) + r.outputTokens;
+  }
+  return buckets;
+}
+
+/** 读成本看板快照（db 未注入/降级时返回全零结构，不抛错）。 */
+export function snapshotTokenCost(granularity: Granularity): CostSnapshot {
+  const now = Date.now();
+  const emptyWindow = (range: CostWindow['range'], ms: number): CostWindow => ({
+    range,
+    since: ms === 0 ? 0 : now - ms,
+    calls: 0,
+    inputChars: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    avgOutputTokens: 0,
+    medianOutputTokens: 0,
+  });
+  if (!db) {
+    return {
+      windows: WINDOW_DEFS.map((w) => emptyWindow(w.range, w.ms)),
+      byModel: [],
+      byLayer: [],
+      byLayerStats: [],
+      trend: { granularity, byLayer: { l1: [], l2: [], l3: [] } },
+    };
+  }
+  // 四窗口总聚合（累计窗口顺带取 byModel）
+  const d = db;
+  const windows: CostWindow[] = [];
+  let byModel: CostByModel[] = [];
+  for (const w of WINDOW_DEFS) {
+    const since = w.ms === 0 ? 0 : now - w.ms;
+    const agg = d.aggregateCost(since);
+    windows.push({ range: w.range, since, ...agg.total });
+    if (w.range === 'all') byModel = agg.byModel;
+  }
+  // 按层级 × 窗口聚合（层级×窗口表格）：每个窗口调一次 aggregateCostByLayer，再按层组装
+  const layerByWindow = WINDOW_DEFS.map((w) => {
+    const since = w.ms === 0 ? 0 : now - w.ms;
+    return { range: w.range, rows: d.aggregateCostByLayer(since) };
+  });
+  const byLayer: LayerCost[] = LAYERS.map((layer) => ({
+    layer,
+    windows: layerByWindow.map(({ range, rows }) => {
+      const row = rows.find((r) => r.layer === layer);
+      return {
+        range,
+        calls: row?.calls ?? 0,
+        inputChars: row?.inputChars ?? 0,
+        outputTokens: row?.outputTokens ?? 0,
+        reasoningTokens: row?.reasoningTokens ?? 0,
+        avgOutputTokens: row?.avgOutputTokens ?? 0,
+        medianOutputTokens: row?.medianOutputTokens ?? 0,
+      };
+    }),
+  }));
+  // 每层级模型统计 + 趋势
+  const offset = localOffsetMs();
+  const byLayerStats: LayerMetrics[] = [];
+  const trendByLayer: Record<'l1' | 'l2' | 'l3', TrendBucket[]> = { l1: [], l2: [], l3: [] };
+  for (const layer of LAYERS) {
+    const dayRows = d.aggregateByBucket(TREND_MS.day, offset, 0, layer);
+    const weekRows = d.aggregateByBucket(TREND_MS.week, offset, 0, layer);
+    const monthRows = d.aggregateByBucket(TREND_MS.month, offset, 0, layer);
+    byLayerStats.push({ layer, models: buildModelMetrics(dayRows, weekRows, monthRows) });
+    trendByLayer[layer] = buildTrend(d.aggregateByBucket(TREND_MS[granularity], offset, 0, layer), granularity, now);
+  }
+  return { windows, byModel, byLayer, byLayerStats, trend: { granularity, byLayer: trendByLayer } };
+}


### PR DESCRIPTION
# feat: token 成本看板 / Token Cost Dashboard

## 功能概述 / Overview

**中文**：给 dsh-layered-memory 增加「蒸馏成本看板」——把每次蒸馏 LLM 调用（抽取 / 去重 / L2 / L3）的 token 成本写入 SQLite 明细表，并在「设置 → 记忆 → 成本」Tab 可视化。

**English**: Adds a "distillation cost dashboard" to dsh-layered-memory — every distillation LLM call (extract / dedup / L2 / L3) is persisted as a token-cost row in SQLite and visualized in a new "Cost" tab under Settings → Memory.

## 动机 / Motivation

**中文**：现有 `src/llm-usage.ts` 是进程内纯内存计数器（面向 bench 的「记忆开销」记账），存在三个缺口：① 不持久化（重启清零）；② 不按模型分组；③ 无面向用户的 UI。本 PR 补齐这三点，并完全复用作者已有的 `recordDistillCall` 埋点位置，侵入面最小。

**English**: The existing `src/llm-usage.ts` is an in-memory counter (for bench accounting) with three gaps: (1) not persisted (reset on restart); (2) not grouped by model; (3) no user-facing UI. This PR fills all three, reusing the author's existing `recordDistillCall` call sites to keep the footprint minimal.

## 数据口径 / Data Conventions（重要 / Important — read before review）

**中文**：
- **输入**：按**字符**记（`input_chars`）。dsh llm 流的 usage 块只携带 output/reasoning token，拿不到输入 token，沿用仓库既有口径。
- **输出 / 思考**：按 **token** 记（`output_tokens` / `reasoning_tokens`）。
- **层级归并**：展示层面归并为 L1 / L2 / L3 三层，其中 `L1 = l1-extract + l1-dedup`。
- **avg / median**：单次调用的**输出 token** 的均值 / 中位数（SQLite 无内置 median，取序列后在 JS 侧计算）。
- **保留策略**：`token_cost` 表保留 **365 天**明细，写入时顺带滚动清理过期行。

**English**:
- **Input**: counted in **characters** (`input_chars`) — the dsh llm stream's usage block only carries output/reasoning tokens, so input tokens are unavailable; this follows the repo's existing convention.
- **Output / reasoning**: counted in **tokens** (`output_tokens` / `reasoning_tokens`).
- **Layer merge**: displayed as three layers L1 / L2 / L3, where `L1 = l1-extract + l1-dedup`.
- **avg / median**: mean / median of **output tokens per call** (SQLite has no built-in median, so the sequence is pulled and computed in JS).
- **Retention**: `token_cost` keeps **365 days** of detail rows, with rolling cleanup on each insert.

## 改动清单 / Changes

| 文件 / File | 改动 / Change |
|---|---|
| `src/token-cost.ts` | 新增：成本账本模块（`initTokenCost` 注入 db + `recordCostCall` 记账 + `snapshotTokenCost` 聚合快照）<br>New: cost ledger module (db injection + call recording + aggregate snapshot) |
| `src/store/sqlite.ts` | 新增 `token_cost` 表 + `insertCostCall`；新增 `aggregateCost`（总聚合/按模型）、`aggregateCostByLayer`（按层级归并）、`aggregateByBucket`（按时间桶+模型）<br>New: `token_cost` table + insert; aggregate queries (total/by-model, by-layer, by-bucket) |
| `src/llm.ts` | `callLLM` 出口记账：成功 / 失败两条路径都调 `recordCostCall`（token 照烧）<br>Record at the `callLLM` exit, on both success and failure paths |
| `src/index.ts` | 启动时 `initTokenCost(db)` 注入（`callLLM` 拿不到运行时创建的 db）<br>Inject db at startup via `initTokenCost(db)` |
| `src/stats.ts` | 新增 `dsh-memory/token-cost` RPC 端点（接受 `granularity` 参数）<br>New `dsh-memory/token-cost` RPC endpoint (accepts `granularity`) |
| `client/client.js` | 新增「成本」Tab：趋势折线图（模型分色 + 层级过滤 + 日/周/月粒度）+ 层级×窗口表格（总量/avg/median）+ 时间窗口总览<br>New "Cost" tab: trend line chart (per-model colors, layer filter, day/week/month) + layer×window tables (total/avg/median) + window overview |

## 影响 / Impact

**中文**：
- 新增 `token_cost` 明细表（365 天滚动，量级很小）
- `callLLM` 出口多一行记账：成功/失败都记；记账本身失败时静默吞掉，不阻断蒸馏
- 新增一个只读 RPC 端点 + 设置页一个「成本」Tab
- 不改变现有记忆蒸馏、召回、存储的任何行为

**English**:
- New `token_cost` detail table (365-day rolling, small volume)
- One extra accounting line at the `callLLM` exit: recorded on both success and failure; accounting failures are silently swallowed and never block distillation
- One new read-only RPC endpoint + one "Cost" tab in settings
- No change to existing distillation / recall / storage behavior

## 验证 / Verification

**中文**：`tsc` 编译通过、`client.js` `node --check` 通过；实测触发一次蒸馏后 `token_cost` 表写入 2 条明细（l1-extract / l1-dedup），字段与调用日志对得上；日/周/月聚合、avg/median 用独立 SQL 复算，数值一致。

**English**: `tsc` passes and `client.js` passes `node --check`; verified end-to-end — after one distillation run, `token_cost` holds 2 detail rows (l1-extract / l1-dedup) matching the call log; day/week/month aggregates and avg/median were re-computed with independent SQL and match.

