### PR TITLE
feat!: 宿主 0.1.2-alpha 兼容同步（0.8.12）——最低宿主版本升至 0.1.2-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@
 > **UI 截图约定**：带界面变化的条目在 `assets/changelog/<版本号>/<两位编号>-<简述>.png`
 > 存真机截图，并在条目内以相对路径引用，读者可在更新日志里直接看到新版本 UI 的样子。
 
+## [0.8.12] — 2026-08-31
+
+### 破坏性变更
+
+- **宿主最低版本提升至 DeepSeek Harness 0.1.2-alpha.1（此后仅支持 0.1.2-alpha.x 宿主线）**：
+  宿主 [v0.1.2-alpha.1](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.1)
+  / [alpha.2](https://github.com/deepseek-ai/deepseek-harness/releases/tag/dsh-v0.1.2-alpha.2)
+  是破坏性更新（组件包移除/迁移大量导出、npm peer 依赖重排、client RPC 错误码并入
+  `gateway/*` 命名空间、会话视图工程拆分），0.8.12 起本插件不再支持 0.1.1-rc.x 及更早
+  宿主（旧宿主请继续用 0.8.11）。注意 npm 上宿主 `latest` 标签仍指向 0.1.1-rc.2，
+  安装命令须显式带 alpha 版本号：
+
+  ```bash
+  npx -y @deepseek-ai/dsh@0.1.2-alpha.2 plugin --profile web add dsh-layered-memory
+  ```
+
+  已装 dsh CLI 的用户先 `npm i -g @deepseek-ai/dsh@0.1.2-alpha.2` 并重启，再升级插件。
+  README（中英文）已同步改为仅声明 0.1.2-alpha.x 支持。
+
+### 变更（宿主 API 迁移）
+
+- **settings 命名空间**：宿主 dsh-settings 不再导出 `settingsNamespace()` 品牌 helper
+  （`register` 改为泛型字面量签名，kebab-case 形状编译期校验、品牌在服务内部解析）——
+  `dsh-memory` 命名空间改为直接传字符串字面量，运行时行为不变。
+- **RPC 通道注册**：宿主 `connection.rpc.handle` 由三参删至两参——`{authority:'loopback'}`
+  选项随宿主移除（回环约束改由宿主侧 Host/Origin fence 与浏览器 token 鉴权统一承担），
+  `/rpc` 通道注册去掉第三参；client 侧调用面不受影响（错误码按不透明字符串处理，
+  宿主侧 `internal → gateway/internal` 改名无感）。
+- **依赖面同步**：peerDependencies 升至 `^0.1.2-alpha.1`（同一范围覆盖 alpha.1/alpha.2
+  与后续 0.1.2 正式版），devDependencies 钉 `0.1.2-alpha.2`（cordis 4.0.2、
+  schemastery 3.18.2，lockfile 相应重生成）；`dsh.client.inject` 清掉宿主已删除的
+  `@deepseek-ai/dsh-client-runtime` 死条目（loader 对缺行本就静默跳过，纯卫生）。
+  宿主的 `@deepseek-ai/dsh-client-ui-primitives` 经核实为 web 平台 seed 模块
+  （boot 时静态内联进模块表），client 侧 `hostRequire` 天然确定性可达，无需声明
+  `dsh.client.external`。
+
+### 验证
+
+- 宿主 0.1.2-alpha.2 真机全链路通过：boot 零错误、蒸馏管线在真实会话触发跑轮、
+  输入栏记忆 pill（四档滑轨展开/外部点击关闭）与设置 → 插件 → 记忆浏览器六 Tab
+  面板（含 L1 数据 RPC 加载）全部正常。typecheck×2 / build / smoke（33 节）/
+  verify-catalog / cordis Config 校验全绿。
+
 ## [0.8.11] — 2026-08-29
 
 ### 修复

--- a/README.en.md
+++ b/README.en.md
@@ -10,21 +10,27 @@
 [简体中文](README.md) · [Latest release](https://github.com/JunNanLYS/dsh-layered-memory/releases/latest) · [Report issues](https://github.com/JunNanLYS/dsh-layered-memory/issues)
 
 [![npm version](https://img.shields.io/npm/v/dsh-layered-memory?color=6f83ff&style=flat-square&label=npm)](https://www.npmjs.com/package/dsh-layered-memory)
-[![DSH 0.1.1-rc.2](https://img.shields.io/badge/DSH-0.1.1--rc.2-8b5cf6?style=flat-square)](https://github.com/deepseek-ai/deepseek-harness)
+[![DSH 0.1.2-alpha.x](https://img.shields.io/badge/DSH-0.1.2--alpha.x-8b5cf6?style=flat-square)](https://github.com/deepseek-ai/deepseek-harness)
 [![MIT License](https://img.shields.io/badge/license-MIT-536990?style=flat-square)](LICENSE)
 
 </div>
 
 ## Getting Started
 
-Requires Node ≥ 22.16. Two invocation styles — the `npx` prefix can replace `dsh` in
+Requires Node ≥ 22.16 and DeepSeek Harness ≥ **0.1.2-alpha.1** (as of 0.8.12 only the
+0.1.2-alpha.x host line is supported; for older hosts see the
+[release history](https://github.com/JunNanLYS/dsh-layered-memory/releases)).
+Two invocation styles — the `npx` prefix can replace `dsh` in
 any command below:
 
 ```bash
-# Option 1: run the official CLI directly via npx (no pre-installed dsh; version can be pinned, e.g. dsh-layered-memory@0.8.4)
-npx -y @deepseek-ai/dsh plugin --profile web add dsh-layered-memory
+# Option 1: run the official CLI directly via npx (no pre-installed dsh; the host version must
+# be pinned to the alpha line — the npm "latest" tag still points to 0.1.1-rc.x)
+npx -y @deepseek-ai/dsh@0.1.2-alpha.2 plugin --profile web add dsh-layered-memory
 
-# Option 2: with the dsh CLI installed (dsh is a pnpm forwarder; npm i -g pnpm first if missing)
+# Option 2: with the dsh CLI installed (upgrade to the alpha line first:
+# npm i -g @deepseek-ai/dsh@0.1.2-alpha.2, then restart; dsh is a pnpm forwarder —
+# npm i -g pnpm first if missing)
 dsh plugin --profile web add dsh-layered-memory
 
 # Alternative sources: GitHub repo / local path (dev & debugging, link: points at the repo; npm run build + restart dsh to apply)

--- a/README.md
+++ b/README.md
@@ -10,20 +10,23 @@
 [English](README.en.md) · [最新发行版](https://github.com/JunNanLYS/dsh-layered-memory/releases/latest) · [反馈问题](https://github.com/JunNanLYS/dsh-layered-memory/issues)
 
 [![npm version](https://img.shields.io/npm/v/dsh-layered-memory?color=6f83ff&style=flat-square&label=npm)](https://www.npmjs.com/package/dsh-layered-memory)
-[![DSH 0.1.1-rc.2](https://img.shields.io/badge/DSH-0.1.1--rc.2-8b5cf6?style=flat-square)](https://github.com/deepseek-ai/deepseek-harness)
+[![DSH 0.1.2-alpha.x](https://img.shields.io/badge/DSH-0.1.2--alpha.x-8b5cf6?style=flat-square)](https://github.com/deepseek-ai/deepseek-harness)
 [![MIT License](https://img.shields.io/badge/license-MIT-536990?style=flat-square)](LICENSE)
 
 </div>
 
 ## 快速开始
 
-需要 Node ≥ 22.16。两种调用方式任选（`npx` 前缀可替换下面任何 `dsh` 命令）：
+需要 Node ≥ 22.16 与 DeepSeek Harness ≥ **0.1.2-alpha.1**（0.8.12 起仅支持
+0.1.2-alpha.x 宿主线；旧版插件请看 [历史版本](https://github.com/JunNanLYS/dsh-layered-memory/releases)）。
+两种调用方式任选（`npx` 前缀可替换下面任何 `dsh` 命令）：
 
 ```bash
-# 方式一：npx 直接跑官方 CLI（无需预装 dsh；可 pin 版本，如 dsh-layered-memory@0.8.4）
-npx -y @deepseek-ai/dsh plugin --profile web add dsh-layered-memory
+# 方式一：npx 直接跑官方 CLI（无需预装 dsh；宿主须带 alpha 版本号——npm latest 仍指向 0.1.1-rc.x）
+npx -y @deepseek-ai/dsh@0.1.2-alpha.2 plugin --profile web add dsh-layered-memory
 
-# 方式二：已装 dsh CLI（dsh 是 pnpm 转发器，未装 pnpm 时先 npm i -g pnpm）
+# 方式二：已装 dsh CLI（先升级到 alpha 线：npm i -g @deepseek-ai/dsh@0.1.2-alpha.2 并重启；
+# dsh 是 pnpm 转发器，未装 pnpm 时先 npm i -g pnpm）
 dsh plugin --profile web add dsh-layered-memory
 
 # 包源备选：GitHub 仓库 / 本地路径（开发调试，link: 指向仓库，npm run build + 重启 dsh 即生效）

--- a/dist/settings.js
+++ b/dist/settings.js
@@ -1,5 +1,4 @@
 import Schema from '@deepseek-ai/schemastery';
-import { settingsNamespace } from '@deepseek-ai/dsh-settings';
 import { EFFORT_CHOICES } from './config.js';
 /**
  * 运行时统一路由链条目：[0] = 主路由（provider/model 双空 = 跟随默认模型），
@@ -63,7 +62,9 @@ export function validateDistillChain(chain, opts) {
     }
     return null;
 }
-const NS = settingsNamespace('dsh-memory');
+// 0.1.2-alpha 起 dsh-settings 不再导出 settingsNamespace 品牌 helper：
+// register 改为泛型字面量签名（编译期校验 kebab-case，品牌在服务内部解析）。
+const NS = 'dsh-memory';
 const ALWAYS_ON = {
     enabled: true,
     capture: true,

--- a/dist/stats.js
+++ b/dist/stats.js
@@ -56,7 +56,7 @@ export function registerMemoryRpc(ctx, cfg, stores, logger, status, live, modes,
                     error: { code: 'internal', message: err instanceof Error ? err.message : String(err), details: {} },
                 };
             }
-        }, { authority: 'loopback' });
+        });
         registeredImpl = connection;
         if (!active) {
             void dispose();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,30 @@
 {
   "name": "dsh-layered-memory",
-  "version": "0.8.7",
+  "version": "0.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-layered-memory",
-      "version": "0.8.7",
+      "version": "0.8.12",
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "3.18.1",
+        "@deepseek-ai/schemastery": "3.18.2",
         "@node-rs/jieba": "^2.0.2",
         "sqlite-vec": "^0.1.7-alpha.2",
         "undici": "^7.29.0"
       },
       "devDependencies": {
-        "@deepseek-ai/cordis": "4.0.1",
-        "@deepseek-ai/dsh-agent": "0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-default-model": "0.1.1-rc.2",
-        "@deepseek-ai/dsh-client-connection": "0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence-jsonl": "0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "0.1.1-rc.2",
+        "@deepseek-ai/cordis": "4.0.2",
+        "@deepseek-ai/dsh-agent": "0.1.2-alpha.2",
+        "@deepseek-ai/dsh-agent-default-model": "0.1.2-alpha.2",
+        "@deepseek-ai/dsh-client-connection": "0.1.2-alpha.2",
+        "@deepseek-ai/dsh-home-paths": "0.1.2-alpha.2",
+        "@deepseek-ai/dsh-llm": "0.1.2-alpha.2",
+        "@deepseek-ai/dsh-session": "0.1.2-alpha.2",
+        "@deepseek-ai/dsh-settings": "0.1.2-alpha.2",
+        "@deepseek-ai/dsh-system-prompt": "0.1.2-alpha.2",
+        "@deepseek-ai/dsh-tools": "0.1.2-alpha.2",
         "@types/node": "^22.0.0",
         "@types/react": "^19.2.18",
         "esbuild": "^0.28.2",
@@ -36,33 +35,32 @@
       },
       "peerDependencies": {
         "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence-jsonl": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/dsh-agent": "^0.1.2-alpha.1",
+        "@deepseek-ai/dsh-home-paths": "^0.1.2-alpha.1",
+        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.1",
+        "@deepseek-ai/dsh-session": "^0.1.2-alpha.1",
+        "@deepseek-ai/dsh-settings": "^0.1.2-alpha.1",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-alpha.1",
+        "@deepseek-ai/dsh-tools": "^0.1.2-alpha.1"
       }
     },
     "node_modules/@deepseek-ai/cordis": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
-      "integrity": "sha512-YBdskTU2Po1kru3GgcUWUbkTsPMA9LkSQDAY8rBkFJeajdgcQad3QPJZE26JyK99Xb6HaASvoXg2DSUTeN/0Nw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.2.tgz",
+      "integrity": "sha512-asOnXP1TzFSFQlHb1iegDZp0z/8WD1c7YNrwJR/Tx2bzNuMXfcekE/I67Iv6SQXeLB4csxqCngzQKANP7gdw0g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "@standard-schema/spec": "^1.1.0"
       },
       "bin": {
         "cordis": "bin.js"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
+        "@deepseek-ai/cordis-plugin-include": "^1.0.7",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.3"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-include": {
@@ -73,593 +71,178 @@
         }
       }
     },
-    "node_modules/@deepseek-ai/cordis-plugin-include": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-include/-/cordis-plugin-include-1.0.6.tgz",
-      "integrity": "sha512-i1VXrZCbv6tk/iUgedCNjrxxArbWT3IvRZGB5sdqJ3ectnihivXXQbRZ8JJ73DSmAPvlMGmrbtjFAfm10yvXRg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
-        "js-yaml": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
-      }
-    },
-    "node_modules/@deepseek-ai/cordis-plugin-loader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis-plugin-loader/-/cordis-plugin-loader-1.0.2.tgz",
-      "integrity": "sha512-RIW9hoVyhYDWdCI9BsvtZccPde1ECLC4OAxupwowGTak78vwVTVdb3HezTSOK1Y1/Ax3Ru0LA1pYOB04CnTxIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "node-addon-require-builtin": "^0.1.4"
-      },
-      "peerDependenciesMeta": {
-        "node-addon-require-builtin": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@deepseek-ai/cosmokit": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2.tgz",
-      "integrity": "sha512-muBOKtSrUKU5m/xpq8ZXWL6hQ/jgd4PhU2PqH97bcxIiLEJfNwZOGQEx4t/aS/GgxRAR+ra9pMHPMtTHU4sqqA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.3.tgz",
+      "integrity": "sha512-qBo+ronVM6Eu2WNVJXi8JcMiqZ19T9BRIpV+5qJUFPXjGH/Z0QKcQMC/IZJ7L394YTOtJgcovbk9qP0w2GsBXQ==",
       "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-cC7lnJe7JgPFcreNXxcxLMxQd78LnpVO9ZXROjZsGRQN1zGH6i/DduI892F1am85IfzzO+XTxMwwUHmfwamb0g==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-K7B5XSQ7byB/IoNGj7n+lBgHCpVPJqEPvpGoHKc1dBS8fPo2yYp/ALFag4YOfrXVP3jQ9A8di20BbvIlp79SoA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-session-projection": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-agent-default-model": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Pv+4p20Eol7Ds/n0OS0vjtChCWfFTJAMThxugXcEcLKEJ9WAtpI4mzWfLgjmeVXnwD2yvp6HlLKDrrQV9PIkww==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-default-model/-/dsh-agent-default-model-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-CSDSK0sWa6luihoUZI2KOz8xFckjYuBPClT6UKRyzgigHdlf1oLOSJpoIrIywpaN6Q3CXFHqFrZ6DYuc5uDAhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-agent-presets": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent-presets/-/dsh-agent-presets-0.1.1-rc.2.tgz",
-      "integrity": "sha512-88r3jkrbdwTgcP3MZLIUX458Ecu8JcLmZa7PtPszwf33yFoWlZvZmgjyn5ETHV55plNQ8gKMRm9a0RwzGGmzCw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "js-yaml": "^4.1.0"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-atomic-write": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-api-gateway": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-gateway/-/dsh-api-gateway-0.1.1-rc.2.tgz",
-      "integrity": "sha512-i/e/Ecg1QCjMePUFHBfjRQU3NbDV0IdORwQbQD6RpiirzyvAIm4vvZgmW/FfgkO2XYJHHIVjo3i1i0YaHPcQag==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-client-connection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-api-remotes": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-api-remotes/-/dsh-api-remotes-0.1.1-rc.2.tgz",
-      "integrity": "sha512-mtmMxA0TZwTjy46E2DF0kmsPCXVq6RBhrwEHWXBaRzc0DLjnYqmJODrZ0X+XwXOkwFZtDxWSv/uheiIsXf8now==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-gateway": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-file-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-plugin-inventory": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-message-feedback": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-reference": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-registry": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-atomic-write": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-atomic-write/-/dsh-atomic-write-0.1.1-rc.2.tgz",
-      "integrity": "sha512-QqNSF0+Ddn6qWY480dlilwEy6FLv3JKEWx1UQgoNJrxD4y54SDRzqBQB9yDXWKOoOGyC+05TN6/Px10GNIzMWA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.1.1-rc.2.tgz",
-      "integrity": "sha512-rCYAt8QsawP1yfDCU7XxNwYT/XWvyFsxYrkwhLLkdfW83QVD0CQHizSkTQE7RFX74nKUD1z3sTLfnLr7xneArw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-settings": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.1-rc.2.tgz",
-      "integrity": "sha512-8vXsAXoUdzKAgvd/E9DgyT6HKmR6ZM4rtJ3fs/XoJ6n2kBk4tWil8Lv+jxCMWJeMOnTJF55gu2+NWQ3ECFPtJw==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-sWFbShCe8LNLuqD3gdQeneUGxFtZ/rywe6Tmi2eteBDubecHnf04XurtF38Epno42bnNTMYWuKwt1cihcbHL3A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-client-connection": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.1-rc.2.tgz",
-      "integrity": "sha512-YX2WLA/aZdDQsien4Zo7IHTEfYVJ+4QhRXbgA6BrRUM23NSP/+V3K00dQYyQVsF3ZwocE5uyvlZvbYeg1Iz4ug==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-client-connection/-/dsh-client-connection-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-au2+lgnwmJboCvW/LXLJvmyAKsUa0iISjS0T5k4TyZ80KbGQo0erIH0E9GnKbbmER6tk/Kaom9AEewAEY8TAjQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "ws": "^8.21.0"
+        "@deepseek-ai/dsh-credentials": "^0.1.2-alpha.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
+        "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-apiproxy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-webserver": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SgFresqH5UABzRQZ7tOfqzOLMHF7089VeH+mfcwNQH5peOavgEKrAGOYz/9RnISH0XmMrj/x177t8gfO8Uvo/w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-commands": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-commands/-/dsh-commands-0.1.1-rc.2.tgz",
-      "integrity": "sha512-BOIe4Sht9rmMv1a6b3GWjWBbeWr7PtHlAy41vgpaymvUUuzOapOIA648ZMGCI/crRIt72Umev2FHtSwCNSbYZg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-compaction": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-compaction/-/dsh-compaction-0.1.1-rc.2.tgz",
-      "integrity": "sha512-LV5GAIx7GO8DCRivnN2bmLmuucsYDG+ifG18BaXBqsVKdrzmaIu5o+CBxQAI2bX1N6mfBenLxmvCnROkyumLTg==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-KGUwcm4sSHjspQYr2Kj1DycaxnPzxg25sk3ychqbFG4cLcUA8W6eqQJEpEUgmnCOkDBx/j9oXvzNxp7XGMsRoQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-cordis-host-runner": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-cordis-host-runner/-/dsh-cordis-host-runner-0.1.1-rc.2.tgz",
-      "integrity": "sha512-+AQGegPy+gdtcjTTPxDDYwAFUn6BB1J/MFFbmpPr+WIqJoDyVsuCDe8Rr8mCJmxs12CmTZXXSOE03LW203W8fA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-credentials": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.1-rc.2.tgz",
-      "integrity": "sha512-aeVBaH07rox7NuSNbSqbz8g0eNb2IIhNbrZngj/VxUsr/TR9TXOq7lm1CL6SBUDlstGw3vNWeXyhim/DmA5iSQ==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-credentials/-/dsh-credentials-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-TnNK478eQ4iGfUvVyMnkj3GneRCxJbAaM2746HE01iRucE8TypFmh+lFj7kfz7Mcp4S00ixJXqyPddwv+/CPLQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-file-reference": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-file-reference/-/dsh-file-reference-0.1.1-rc.2.tgz",
-      "integrity": "sha512-8Pd4SNHhV6OlbwfV5K4qmFb709I0Z68qgaUQJ7zM4BTjClNe1/dktQnETtWPfqbPTx/2sNKXM1rz4WXuROrIfQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "zod": "^4.4.3"
+        "@deepseek-ai/dsh-brand": "^0.1.2-alpha.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-goal": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-goal/-/dsh-goal-0.1.1-rc.2.tgz",
-      "integrity": "sha512-lSHTh4vfS6eRb9to/y+bjRf2+0QkNpY3tHJ29HMTewR9fJYZsEVVu4Hc+GPhPEjF7RpiD35/sKx+akijtDasyg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-home-paths": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.1-rc.2.tgz",
-      "integrity": "sha512-lGsP7sbnu20AiRAb+gxYiKx9oa9r1D/8Fr6BwWHXpaPx6ZE4Qg0+ybh5SZVfGQ+XhLcQisu3nwWemEjtTJGiig==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-apiproxy": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-apiproxy/-/dsh-host-apiproxy-0.1.1-rc.2.tgz",
-      "integrity": "sha512-dplRnGGXXsQYFQ1KMHymAM0iaxuE9Z153JHYcGEgOwXNkS3HA20gSi3yMt6fz+zi/cMHYXvY1JQhS54BTc761A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-default-model": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-api-remotes": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-commands": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-credentials": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-goal": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-host-directory-picker": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-native-command": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-skill": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-subagent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-questions": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-workspace": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "fflate": "^0.8.2",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-cordis-host-runner": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-directory-picker": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-directory-picker/-/dsh-host-directory-picker-0.1.1-rc.2.tgz",
-      "integrity": "sha512-m3puwS+bvJQ1eASdpEEwlQqKa9znhBSgtoSSI0GZN5VMynZVl7E31HMltENz3QC2Nd+C3bh7vNjrJFtumUDsLQ==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-home-paths/-/dsh-home-paths-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-L4mLwpZvBuKLSRjjSI6lFGUmUTbjcMcMuX1PWbhHKphmvaokQXf6jqNgD/I6VfIg0BnS2rO/jPqasOQUxRNlYw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-plugin-inventory": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-plugin-inventory/-/dsh-host-plugin-inventory-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Hud9ezW0bexWfhX7C+c5rdUDX1xzbEGDzj1lGQyj/QxdrxHYHjGrJq3tLRyvN6K4FSmEdG2IBKdQGCOLVrIthA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-host-webserver": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-host-webserver/-/dsh-host-webserver-0.1.1-rc.2.tgz",
-      "integrity": "sha512-t9MrjC65QHiiWhG9V8UZxgfE/aWYhJHHrIM0kbTvtXxg4tLGIKo/upHp7iiag65F3HTkVLrH/DUyPMi4v2ZA7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.1-rc.2.tgz",
-      "integrity": "sha512-l+1Om/EDFyMjhgSuEx2WDLLA2fia/+ga9mBTCoT/MMslsnWaK5G0/lWwbwlTBSaJ6OfmYc3DuBgox8DbgIGHRQ==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-1ewUeCzUHbaqhtW5rG1/eujIXXzy2VhwvMa16RpcTuJp5qcU1NtAf/+COkmvI7qtkyNY61vWg1Ez5qL9hKIUpQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-jobs": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-jobs/-/dsh-jobs-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SXvDJMvcUrGrlzIyE7j8/lI4Pj1nDe/UOR8C05Zagp+/0R8p46n6KylySvZdPAFENV5t8WX3Fw3eOaS4No0+wQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ASJfjIdZbIXvLwi3rGo+eZb/GxMVV/WO5/XVD3B96mT8EIzrlw3+nMR6/CvmJVzcycKQ2XN0wj7jD6TasPRySA==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-ip6yMxwHugxQm4VCbwX/FDnlTeeBM9VBkIn0+74ityQy7Z3yKREJ1Ov8Z04l4G3duRzeGRsQ4ztOFZ01oNfKIw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-attachment": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-message-feedback": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-message-feedback/-/dsh-message-feedback-0.1.1-rc.2.tgz",
-      "integrity": "sha512-GzxDiNvyUVs/bbbm+Hr3MfuU3wM8ErRF5z9XadnSGPYZvipZDAMrvrS5v6JgOUaZt6ApBpEMJ4xVgIel1VnGYQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
+        "@deepseek-ai/dsh-brand": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-timeout": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-typert-protocol": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-util-crypto": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-alpha.2",
+        "@deepseek-ai/schemastery": "^3.18.2",
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-native-command": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-native-command/-/dsh-native-command-0.1.1-rc.2.tgz",
-      "integrity": "sha512-GIknPrwU7vZOUQ2o/ES7Z0uUhUrZGp/yigKP+RXEu41VI9tcybiXQAA8CEdDFmNQ11R2wfYQhr3WO5vy35akWg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-output-retention": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-output-retention/-/dsh-output-retention-0.1.1-rc.2.tgz",
-      "integrity": "sha512-tCni+bTEp/FWokfz3fqn4p6SzHn6pkY6H3HkS9UY5PHrztUE1ESUQUp41kIVtwUhRmJU7yissqjxe6kLDB6t2Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.1-rc.2.tgz",
-      "integrity": "sha512-Xy3ejL6dwVSluZL7XOWy76ya4pCw1uHwxodDK4O9XiQUiUV4FBXnt0aNJUtMeAFN0c1YujxxCmRniMvuuNn1Nw==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-jeWfQnftQeZOWujxndgU6kjoFuXGWqmFrkWAxlWmyeojK/iyZqAxayWPuhVUEgweh4EWJmn6rW5HV3E4DXWuWw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.1-rc.2.tgz",
-      "integrity": "sha512-4/cv6X9HPhm47eyRhCu/WZwzrtJKegk5J+0xaxcZ9i8S0smdxP57tqy8a0jkSshLQn7BzMFxneQrlYExrLrDhQ==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-RfikXscYTDXDr7CD7C/8oGJZaH8Egclj7pmXRtd90QcB5L8RIQ7069xrHZjds8OjNrFo69qQwNK3gYLUVZy9PA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-persistence": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence/-/dsh-session-persistence-0.1.1-rc.2.tgz",
-      "integrity": "sha512-dxdYxRfmK5jWtiFFabqRNb/jGGjkXyF2djI7O8IIKmDVjhQiv170zpvhbAhRUuqClEdseCtbQpLBrRm2blzt3g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-timeout": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-persistence-jsonl": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-persistence-jsonl/-/dsh-session-persistence-jsonl-0.1.1-rc.2.tgz",
-      "integrity": "sha512-1H+boST8tlc8fu5VVClcCRFGI18dH1EOAzfC+HsQZ+GiC7jhPN112oJWyzxKot1P07bmKdKev3un4VR2Chr/aw==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "koffi": "^3.1.0"
+        "@deepseek-ai/dsh-brand": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-alpha.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-session-projection": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SNaOrjRS4RMXocna6uL33TeS/uhcQ7jDJtJZ1HyDPL06mXUdAgje2MVt8OZCh6dH95xIiqpQQm+KjzeiQnhYSQ==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection/-/dsh-session-projection-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-E5NYRAOQwiYYu56WSHTlnI2MkyqznA4ePlOdOQvpF97a7ZG2BkRfflwvQ5NHIPv8FABemoSCGMiI3/0GSfqvBg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -667,348 +250,143 @@
         "zod": "^4.4.3"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-projection-cache": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-projection-cache/-/dsh-session-projection-cache-0.1.1-rc.2.tgz",
-      "integrity": "sha512-UvCRpIb+LoQI/nCLof17xc2P2KuZoucU3VuzfAukfsF3dYZAy5OP7jrCRdVZIvjRfvFUd7G+awdS9sWbnjcolg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-query": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-query/-/dsh-session-query-0.1.1-rc.2.tgz",
-      "integrity": "sha512-QxQFRg/KnrZnYiO7fNtTJVTakuGs9ZFRkGGgYuNPzSz1pRqiohGNE/JZzBtq+HMv38RRTRZrM4aIOUV8OgqoXQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-title": "^0.1.1-rc.2"
-      },
-      "peerDependenciesMeta": {
-        "@deepseek-ai/dsh-session-persistence": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-reference": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-reference/-/dsh-session-reference-0.1.1-rc.2.tgz",
-      "integrity": "sha512-c9mz19ndxjVxSnXEhmJwGDjyKG4oNmu4Sfneix8OUJ+mAr3jIgb/QZZ8rYEc8Bi+Dd1z7Wr90IeWOBF0nolU3A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-compaction": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-output-retention": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-query": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-session-title": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session-title/-/dsh-session-title-0.1.1-rc.2.tgz",
-      "integrity": "sha512-qHv+9nE6J/piHsWwckmbJBS1sJjunCWsv00arhsgjW1XMLCHxG6QOB+U48P4EBZjve798Tz8AQIlWZy+9T8XmA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-settings": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.1-rc.2.tgz",
-      "integrity": "sha512-iGdKEt91Im3gE7xA9CzRfTJsPcFcxDeDOCLhAjzbpjEv7TAjx/EoYP7lPtiy+QmOjKSKy206SEtAKol9PXWbOw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/schemastery": "^3.18.1"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-skill": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-skill/-/dsh-skill-0.1.1-rc.2.tgz",
-      "integrity": "sha512-FACjlOqdsWX+0RtSs3RWrdY0QQEpPJrBfvxUbWSh7E8UyCM8dKdIbsQnuXIjsAgC7GgYp7lyFDSCMovQ3ARp8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-storage": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage/-/dsh-storage-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ptJ1ss8spF+Y2VXjsMV37Qh1+hviYWZylDvXtfEBXjLbPi/BP3dktT4B6OMIAD1rRN+0A4HdTqJBgLk7Gp1rig==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-storage-domain": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-storage-domain/-/dsh-storage-domain-0.1.1-rc.2.tgz",
-      "integrity": "sha512-9/3OuaZpxf9NZWhrARpgZ7UBa03pPaTIiDBw+SfESfwVk42NNLVCQgvnEbrWoNwdtzmv0aYCEV23sKwwlQ0LBA==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-settings/-/dsh-settings-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-rWPH/LfDU9SCFaonqfxCMjnD4gkO31DlQVHL9LIy7wH/FVqnBJ6v13YN70Fpof2KKPyL2YhcwOOPQbusxlzSDw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1",
-        "zod": "^4.4.3"
+        "@deepseek-ai/dsh-util-values": "^0.1.2-alpha.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-subagent": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-subagent/-/dsh-subagent-0.1.1-rc.2.tgz",
-      "integrity": "sha512-CNa0WuFCR69TMnBKYQInz49/olDSaVHiYkDTyTuDh7YW7Y80/f/HjQe5G0fQaqZMLla3IUSXCIPl5EssWmjcQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-agent-presets": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-jobs": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-sandbox-policy": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-projection-cache": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-tools": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
-      },
-      "peerDependenciesMeta": {
-        "@deepseek-ai/dsh-agent-presets": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-jobs": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-sandbox": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-sandbox-policy": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-session-persistence": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-session-projection": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-session-projection-cache": {
-          "optional": true
-        },
-        "@deepseek-ai/dsh-user-approval": {
-          "optional": true
-        }
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-alpha.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.1-rc.2.tgz",
-      "integrity": "sha512-on4hjAlYI5uX9q7Sf95YkMMBVe6heywtA/H50ksrIMUub8U2B98hO9iQpHhjwIO1F1vu+5pLcPvRr6yUGGmtXQ==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-qT9PZEVMAbszsg1UVUvuovfWFS5unjy08KV0rnOc89TJCgkb2CnlknSyIQs0lXc/UiqT6ZQ59i4ClAFrXhxfxQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.1-rc.2.tgz",
-      "integrity": "sha512-RrouVgU3G5gXr9zHhpThkMG6YKdcRJzXXdPm1dq3ioBxbvxlfMSfNY4tN8lWMJxLyGtvWkPra0HQX+YWxvdOOA==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-8q5cd55aMoOvrPaqSws/3xiyzHhs1bfjdtAs4YHWimQgMd+yMrDnlu8i+zFOkWoSc0A2wPkXcCYR8xogl4gerA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-tools": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.1-rc.2.tgz",
-      "integrity": "sha512-0GGL4D55MwYDepzZMOI3L0ycu5b2qr96GL0Y7snwhAnpK2Di61rbX3fJE+PB3ZrovGX0csIRdt9n3iJZDVtDrw==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-trk0fkmCDp64pqdcr8u7rCcRrwNi+93FKuznTnCD+YsPGFygcSG/6n+Wsh4+9A6oI1fM4/Ecq6Baa9vq1sNhJg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/dsh-brand": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-util-values": "^0.1.2-alpha.2",
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-code-runtime": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-user-approval": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-code-runtime": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-user-approval": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-typert-protocol": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.1-rc.2.tgz",
-      "integrity": "sha512-lxBssDc5Pz1qBE5kuIyaArA7AvIPq9rpaVclylodiSzVJe95e2xruBg73tflyjtd8y00toet+DLgQ6tSSsq6Kw==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-protocol/-/dsh-typert-protocol-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-U3j/usWHRllaJMdTr4GuVkkUciHWyq01mvMtWeGT+RY2hb+ysTxeuLEiV0Lh5EyVScgFdDLbe/GtTZ2OkGsGwQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
-      }
-    },
-    "node_modules/@deepseek-ai/dsh-typert-registry": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-typert-registry/-/dsh-typert-registry-0.1.1-rc.2.tgz",
-      "integrity": "sha512-ATZu3i7UId+ktsWW3pUFm5Hi1fVsRXFmByATVPp2RlxH1zjxXnauVW6k70ZwU/4FOsphRzo65SXOlAXA+natYg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@deepseek-ai/dsh-typert-protocol": "^0.1.1-rc.2",
-        "zod": "^4.4.3"
-      },
-      "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.1-rc.2.tgz",
-      "integrity": "sha512-SdsO4Rs+NeJFoertkVilXBACREOLfkKPJJznYKqDhJxeRo38RJ56dtj0Xd0/6rERmsQiMck4Bwdrzg1ubUqPNA==",
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-CcV3hf2Q0NYxRbnlE+IysaUkq/hvmjlvS9OGiHpARZVY4VlidlZRmsy5g5L17vDoxirX+WBJ9Cc5VcJMcjPrUg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1"
+        "@deepseek-ai/schemastery": "^3.18.2"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-scope": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-agent": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-brand": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-llm": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-scope": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-session": "^0.1.2-alpha.2",
+        "@deepseek-ai/dsh-system-prompt": "^0.1.2-alpha.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-user-questions": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-questions/-/dsh-user-questions-0.1.1-rc.2.tgz",
-      "integrity": "sha512-9lYoB7qCFE+Vvgwjny3MnRfS7QUefOspj4KpE3b30DAAJfxwrU4hRtLCHOKxyurF01qrkoEBBpXn4H5ilXYTKg==",
+    "node_modules/@deepseek-ai/dsh-util-crypto": {
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-crypto/-/dsh-util-crypto-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-03WVzlgLErJRRGMqaMdx5ufEoN3Scpdsnd0f8vXMhcbeEzKZ61lbI8z/m6ZttM/LhpzPALuFtDc5u+N5LFP8Fg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-llm": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2"
       }
     },
-    "node_modules/@deepseek-ai/dsh-workspace": {
-      "version": "0.1.1-rc.2",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-workspace/-/dsh-workspace-0.1.1-rc.2.tgz",
-      "integrity": "sha512-jBUob4H5TZAiExq9YNVCglKAFmAKMtd1UbyqFfnZZ1Owm+3c3NbAXY947MHiD6NwCwFEW1y7FjrFj66UQvG90A==",
+    "node_modules/@deepseek-ai/dsh-util-values": {
+      "version": "0.1.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-util-values/-/dsh-util-values-0.1.2-alpha.2.tgz",
+      "integrity": "sha512-ZyZHTqGQ/8S5ZYflTkuiZGPxhkuHa9Uy5G+teEmnmnkhiN/UVPGQvI//CXRNmxpTKjfx+qcVVmr5x6bohplsQg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "zod": "^4.4.3"
-      },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1",
-        "@deepseek-ai/dsh-brand": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-invariants": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-session-persistence": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage": "^0.1.1-rc.2",
-        "@deepseek-ai/dsh-storage-domain": "^0.1.1-rc.2"
+        "@deepseek-ai/cordis": "^4.0.2",
+        "@deepseek-ai/dsh-invariants": "^0.1.2-alpha.2"
       }
     },
     "node_modules/@deepseek-ai/schemastery": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1.tgz",
-      "integrity": "sha512-Qn0FCSwCQnpnj6SB31I6i2sIKgKWnkbJM8O0EU91Gv2UsYVvtZTl6IA0sCwk2e2MZf5S8w5hpq9QkeVvK9qwxg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.2.tgz",
+      "integrity": "sha512-njDtZsznjYxok7KLLlHOPyuv2efdWVbSflAHgztSfbMsg+CVraEoRe2DjOCgClYv3ZCSm7WXoaUkbB/+RY7tWQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2",
+        "@deepseek-ai/cosmokit": "^1.8.3",
         "@standard-schema/spec": "^1.1.0"
       }
     },
@@ -1454,261 +832,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@koromix/koffi-darwin-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.6.tgz",
-      "integrity": "sha512-8FHyXGCZN7/iQf4f7W5BRysmtdlAFvSx6FpmX4u6wmkZiX/2e9hIRdGLiZYlHGudlcA18UmXB/cMiyhJ7fJkzA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-darwin-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.6.tgz",
-      "integrity": "sha512-uzx/jqFQuSHqgg1zaRidTBTCfj8Y9M0SDTO8HeoI9s9fJhiJ1mbB9TTwJO5c2hiMnuWg2m1byczC8BaIH6cG/w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-freebsd-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.6.tgz",
-      "integrity": "sha512-PjpTVrsCK5YTtixOw7VsseYXJOyoY6k0qBt+bf0T9h3wyV06y73rALsorFDDEoYpLUBZO7R6EIMs6CpUrEkNTQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-freebsd-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.6.tgz",
-      "integrity": "sha512-ETYwL820HtFwYoOVzgyvmFmzTHRo9DJtGYTxa5Nb7ajaa5ldCum0jbmUJ3PMECxFTLxD5Q6PYZ8Xbp101bGeSg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-freebsd-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.6.tgz",
-      "integrity": "sha512-BkqxkNXhAAT9toU2stvLwx1iKHPDx7h08NCICyBbjYEXkCAEr84igTkpE5V3XJ9xZZ2gKll7VvdhxorHtHUqZw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-linux-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.6.tgz",
-      "integrity": "sha512-cM4XPm9ljbCrcPgXjzFYjDNxDUvvuR7TCYaEoo1AKjwZT/vmWhu2xN3pomfbsHh6aVn80SFA3enufQnaETW1rQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-linux-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.6.tgz",
-      "integrity": "sha512-l1SVTpO10iaQt8slbowJpzK4fbwQZ7ufj9tmCyAcIwWUpyAbPS83mJMctU72If6N9/gCS2wuRqwnYB2uPLLhLg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-linux-loong64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.6.tgz",
-      "integrity": "sha512-KpTJpMSbIdCVFU26ynt0xy4x15h+y6AwPJxj2+iVxJhCzJf4oisCPc0YH2VnutuLV2nVzSrFm7sL/WSOqPgkXw==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-linux-riscv64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.6.tgz",
-      "integrity": "sha512-YdFNpsywnXiYOYQlDAatf7TJLnspbGXdmfwIZhf82kbKSflYUsq4tI6NmoUOzM89oIWDGpYqd4Hz3xL7tsyXsw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-linux-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.6.tgz",
-      "integrity": "sha512-Xx5mpr9VcaMCXfvbqIiLIWIL9Iuu6F4r3iMXg7+zZCqYUFZPFwJgiDQBLxctHv2OYgIfAoaaHMW0GC1cJkHfbA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-openbsd-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.6.tgz",
-      "integrity": "sha512-39Np4QTxhTlTT6RRveIeP+TnbzrwuDJ0UMyHxEZ+oGtzmb9GqWhl9T1oyehG6v/O+c4BffafG2NwLkCZ7tDKWw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-openbsd-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.6.tgz",
-      "integrity": "sha512-3EynGn3ycQRqaMWGmUJ0tdtuQdStByqSy/tJ0ZGKWizbMGdFAE73YpgLsyd8BDvwnKWytVG/OLNb5nDHpfd9Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-win32-arm64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.6.tgz",
-      "integrity": "sha512-27FdPPRtT4xbO9bsd2OZa95M5YQ7bcJ8QjCRO57UUMI21REfkDegjqKwqo/CFlugxXlJf5IYtG2rq4BEYIrvxg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-win32-ia32": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.6.tgz",
-      "integrity": "sha512-5mVelLKVDup4eoxZOpCzCyMPxoctsg+Qe4J9O5BP4KbBEdqoOEqaNEBBRgNzXcdr2g+GGfmIUo+oVR1NvIdiJw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
-    "node_modules/@koromix/koffi-win32-x64": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.6.tgz",
-      "integrity": "sha512-lPKjAaHz0aoiZXT/wDVqH+joR5y3lCZj1s9Bk5qx/DGRq+0MK8Ib8VoqiBOrJ69NG5AsJSvn0tQDcSqfRgLmBQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
     "node_modules/@node-rs/jieba": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@node-rs/jieba/-/jieba-2.0.2.tgz",
@@ -1971,13 +1094,6 @@
         "csstype": "^3.2.2"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2025,64 +1141,6 @@
         "@esbuild/win32-arm64": "0.28.2",
         "@esbuild/win32-ia32": "0.28.2",
         "@esbuild/win32-x64": "0.28.2"
-      }
-    },
-    "node_modules/fflate": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
-      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/koffi": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-3.1.6.tgz",
-      "integrity": "sha512-ln60chEb3o7Du1ayjwl6BFiNN1wZK+3cTM2wWGiHLEzCY/FdTIN1ER5VWDwHq7J/j4tSnnrHaH5ABS1EO6+6ag==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      },
-      "optionalDependencies": {
-        "@koromix/koffi-darwin-arm64": "3.1.6",
-        "@koromix/koffi-darwin-x64": "3.1.6",
-        "@koromix/koffi-freebsd-arm64": "3.1.6",
-        "@koromix/koffi-freebsd-ia32": "3.1.6",
-        "@koromix/koffi-freebsd-x64": "3.1.6",
-        "@koromix/koffi-linux-arm64": "3.1.6",
-        "@koromix/koffi-linux-ia32": "3.1.6",
-        "@koromix/koffi-linux-loong64": "3.1.6",
-        "@koromix/koffi-linux-riscv64": "3.1.6",
-        "@koromix/koffi-linux-x64": "3.1.6",
-        "@koromix/koffi-openbsd-ia32": "3.1.6",
-        "@koromix/koffi-openbsd-x64": "3.1.6",
-        "@koromix/koffi-win32-arm64": "3.1.6",
-        "@koromix/koffi-win32-ia32": "3.1.6",
-        "@koromix/koffi-win32-x64": "3.1.6"
       }
     },
     "node_modules/sqlite-vec": {
@@ -2193,32 +1251,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/ws": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
-      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-layered-memory",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "L0~L3 分层蒸馏记忆插件 for DeepSeek Harness：自动捕获对话（L0）、抽取原子记忆（L1）、整合场景块（L2）、蒸馏核心画像/团队方法论（L3），并在模型步骤前自动召回注入。移植自 MemoryCore (TencentDB Agent Memory) 的管线设计。",
   "type": "module",
   "main": "dist/index.js",
@@ -19,7 +19,6 @@
     },
     "client": {
       "inject": [
-        "@deepseek-ai/dsh-client-runtime",
         "@deepseek-ai/dsh-client-connection"
       ],
       "platform": "web"
@@ -53,32 +52,32 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@deepseek-ai/schemastery": "3.18.1",
+    "@deepseek-ai/schemastery": "3.18.2",
     "@node-rs/jieba": "^2.0.2",
     "sqlite-vec": "^0.1.7-alpha.2",
     "undici": "^7.29.0"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-agent": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-home-paths": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-llm": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-session": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-settings": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-system-prompt": "^0.1.1-rc.2",
-    "@deepseek-ai/dsh-tools": "^0.1.1-rc.2"
+    "@deepseek-ai/dsh-agent": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-home-paths": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-llm": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-session": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-settings": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-system-prompt": "^0.1.2-alpha.1",
+    "@deepseek-ai/dsh-tools": "^0.1.2-alpha.1"
   },
   "devDependencies": {
-    "@deepseek-ai/cordis": "4.0.1",
-    "@deepseek-ai/dsh-agent": "0.1.1-rc.2",
-    "@deepseek-ai/dsh-agent-default-model": "0.1.1-rc.2",
-    "@deepseek-ai/dsh-client-connection": "0.1.1-rc.2",
-    "@deepseek-ai/dsh-home-paths": "0.1.1-rc.2",
-    "@deepseek-ai/dsh-llm": "0.1.1-rc.2",
-    "@deepseek-ai/dsh-session": "0.1.1-rc.2",
-    "@deepseek-ai/dsh-settings": "0.1.1-rc.2",
-    "@deepseek-ai/dsh-system-prompt": "0.1.1-rc.2",
-    "@deepseek-ai/dsh-tools": "0.1.1-rc.2",
+    "@deepseek-ai/cordis": "4.0.2",
+    "@deepseek-ai/dsh-agent": "0.1.2-alpha.2",
+    "@deepseek-ai/dsh-agent-default-model": "0.1.2-alpha.2",
+    "@deepseek-ai/dsh-client-connection": "0.1.2-alpha.2",
+    "@deepseek-ai/dsh-home-paths": "0.1.2-alpha.2",
+    "@deepseek-ai/dsh-llm": "0.1.2-alpha.2",
+    "@deepseek-ai/dsh-session": "0.1.2-alpha.2",
+    "@deepseek-ai/dsh-settings": "0.1.2-alpha.2",
+    "@deepseek-ai/dsh-system-prompt": "0.1.2-alpha.2",
+    "@deepseek-ai/dsh-tools": "0.1.2-alpha.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.18",
     "esbuild": "^0.28.2",

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -48,7 +48,7 @@
     `bm25.ts`（仅 L2 场景摘要选上下文用）+ `io.ts`（原子写等文件原语）。
 - `tools/index.ts` — 模型工具：memory_search / conversation_search / memory_read_scene
   （execute 的 `exec.agent.id === sessionId` 用于按会话档位过滤）。
-- `stats.ts` — 通用 RPC 端点 `dsh-memory/*`（authority=loopback），供 client 状态页与输入栏控件拉数据。
+- `stats.ts` — 通用 RPC 端点 `dsh-memory/*`，供 client 状态页与输入栏控件拉数据。
 - `llm.ts` / `config.ts`（Schemastery schema + MemoryConfig）/ `types.ts` / `util/`。
 - `smoke.ts` — 冒烟测试（不依赖 DSH 运行时，纯 assert；第 21 节对 dist/client.js 产物断言）。
 
@@ -223,8 +223,10 @@
 - **事件**：`session/event (session, event)` emit 模式；`agent/pre-step (payload, next)` waterfall
   必须调 next；`SessionEventMap` 中 `user/message` 的 data 就是 UserMessage，
   `assistant/message` 的 data 是 `{ turn, step, message, usage? }`。
-- **Host↔Client RPC**：Host `ctx.connection.rpc.handle('/rpc', handler, { authority: 'loopback' })`
-  返回**同步**的异步 disposer（`() => Promise<void>`，不能 .then 链）；Client
+- **Host↔Client RPC**：Host `ctx.connection.rpc.handle('/rpc', handler)`（0.1.2-alpha 起
+  两参——第三参 `{authority:'loopback'}` 已删，回环约束改由宿主侧 Host/Origin fence +
+  浏览器 token 鉴权统一承担）返回**同步**的异步 disposer（`() => Promise<void>`，不能
+  .then 链）；Client
   `ctx.connection.rpc.call('/rpc', endpoint, payload)` 返回 `RpcResult`（`{ok,value}|{ok,error}`）。
   connection 是可选服务且可能晚于插件就绪：探测 + 监听 `internal/service` 事件补注册。
 - **Context 声明合并要靠 import 拉进来**：`ctx.get('connection')` 想拿到类型，必须

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,7 +7,7 @@ import type { Context } from '@deepseek-ai/cordis';
 // 纯类型导入：拉入 ctx.settings 的 Context 声明合并
 import type {} from '@deepseek-ai/dsh-settings';
 import Schema from '@deepseek-ai/schemastery';
-import { settingsNamespace, type SettingsScope } from '@deepseek-ai/dsh-settings';
+import type { SettingsScope } from '@deepseek-ai/dsh-settings';
 import { EFFORT_CHOICES } from './config.js';
 import type { MemoryLogger } from './types.js';
 
@@ -84,7 +84,9 @@ export interface LiveSettingsHandle {
   update(patch: Partial<MemoryLiveSettings>): Promise<void>;
 }
 
-const NS = settingsNamespace('dsh-memory');
+// 0.1.2-alpha 起 dsh-settings 不再导出 settingsNamespace 品牌 helper：
+// register 改为泛型字面量签名（编译期校验 kebab-case，品牌在服务内部解析）。
+const NS = 'dsh-memory';
 
 const ALWAYS_ON: MemoryLiveSettings = {
   enabled: true,

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -157,7 +157,6 @@ export function registerMemoryRpc(
           };
         }
       },
-      { authority: 'loopback' },
     );
     registeredImpl = connection;
     if (!active) {


### PR DESCRIPTION
## 变更

同步宿主 DeepSeek Harness v0.1.2-alpha.1 / alpha.2 破坏性更新，发布 **0.8.12**。

### 破坏性变更
- **最低宿主版本 0.1.2-alpha.1**（peer `^0.1.2-alpha.1` 同范围覆盖 alpha.1/alpha.2/0.1.2 正式版；0.1.1-rc.x 不再支持）。npm 宿主 `latest` 仍指 0.1.1-rc.2，安装命令须显式 `@deepseek-ai/dsh@0.1.2-alpha.2`——README 中英文已同步声明。

### 宿主 API 迁移（仅有的两处调用点漂移）
- `settingsNamespace()` 在 alpha.2 移除 → 命名空间改传字符串字面量（新泛型签名编译期校验，运行时行为不变）
- `connection.rpc.handle` 三参→两参（alpha.1 起 `{authority:'loopback'}` 删除，回环约束由宿主 fence + token 鉴权承担）

### 依赖面
- devDeps 钉 `0.1.2-alpha.2`、cordis `4.0.2`、schemastery `3.18.2`（dsh-settings alpha 的 peer 要求）；lockfile 重生成（旧树 rc.2 传递闭包引发 ERESOLVE）
- `dsh.client.inject` 清理宿主已删除的 `dsh-client-runtime` 死条目

### 验证
- typecheck×2 / build / smoke 33 节 / verify-catalog / cordis Config 校验全绿；client bundle 字节未变
- 宿主 0.1.2-alpha.2 真机：boot 零错、蒸馏管线真实跑轮、pill（四档浮层/外部关闭）、设置→插件→记忆六 Tab 面板、L1 RPC 数据加载全部正常
- alpha.1 运行时兼容经源码核验（品牌是编译期 cast；两参 handle 在 alpha.1 即如此）

CHANGELOG 含完整迁移指引。