### PR TITLE
兼容 CLI/TUI 终端形态——/memory 命令 + 状态行 + 设置区块——0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@
 
 > **支持版本约定**：每个版本条目首行标注所支持的 DSH 宿主版本范围（自 0.10.0 起）。
 
+## [0.11.0] — 2026-09-07
+
+支持 DSH 宿主 **0.1.2-alpha.1 ~ 0.1.2-rc.1**；TUI 原生接缝兼容 **dsh-tui 0.10.0-beta.x**。
+
+### 新增（CLI / TUI 终端形态支持）
+
+- **可在终端形态宿主（dsh-tui profile）下运行**：`dsh plugin --profile dsh-tui add dsh-layered-memory`
+  安装后，捕获 / 蒸馏 / 召回 / 工具全链路与 web 形态一致工作。
+- **`/memory` 命令**（全形态注册）：`/memory <auto|chat|work|off>` 切换当前会话记忆档位；
+  无参数时在 TUI 中弹出档位选择面板，web / headless 环境回用法提示。
+- **TUI 状态行**：提示框上方常驻「记忆:智能 / 对话 / 工作 / 暂停 / 停用」当前会话档位读数。
+- **TUI 设置区块**：`/settings` 内可直接编辑总开关、捕获、蒸馏、召回、蒸馏思考档位、
+  蒸馏模型路由与输入预算（与 web 设置面板同一存储；复杂路由链仍走 web / YAML）。
+- 三个接缝（tuiStatus / tuiDialogs / tuiSettingsSections）全部软探测：web / headless
+  形态自动跳过，零开销零风险。
+
 ## [0.10.0] — 2026-09-06
 
 支持 DSH 宿主 **0.1.2-alpha.1 ~ 0.1.2-rc.1**。

--- a/README.en.md
+++ b/README.en.md
@@ -70,6 +70,26 @@ and the memory chip in the input bar (`Memory · Auto`) mean the client half is 
 **Uninstall**: `dsh plugin --profile web remove dsh-layered-memory` + restart. Data
 stays in `~/.dsh/memory/`; delete the whole directory manually if you don't need it.
 
+### Terminal Hosts (TUI / headless)
+
+Beyond web, the same plugin installs into terminal-shaped hosts:
+
+```bash
+# dsh-tui (Claude Code style TUI front door — see github.com/ccch1mneyyy/dsh-TUI)
+dsh plugin --profile dsh-tui add @deepseek-harness-tui/dsh-tui   # first time: create profile + install the TUI host
+dsh plugin --profile dsh-tui add dsh-layered-memory
+dsh --profile dsh-tui
+```
+
+- **`/memory <auto|chat|work|off>`** switches the current session's memory mode; with no
+  argument a selection panel pops up;
+- **Status line**: a persistent `记忆:智能`-style mode readout sits right above the prompt;
+- **`/settings` section**: master switch, capture, distill, recall, distill model routing and
+  input budget are editable in place (same store as the web settings panel; complex routing
+  chains still go through web / YAML);
+- **headless** (`dsh --profile headless "one-shot task"`): capture and distillation work as
+  usual with no UI elements. Web and terminal hosts share the same `~/.dsh/memory/` store.
+
 ### Development from Source
 
 ```bash
@@ -184,6 +204,8 @@ lives in the native host seat designed for it; the plugin no longer owns a strip
   toggle in Automation. Ideal for debug/eval/sensitive sessions that should absorb
   without interference. Orthogonal to Paused: paused is full stealth (capture off
   too), while write-only keeps the "in" and gates the "out".
+- **Terminal host (TUI)**: the same mode system surfaces in the dsh-tui host as the
+  `/memory` command, a status line and a `/settings` section (see Quick Start).
 
 ## UI Preview
 

--- a/README.en.md
+++ b/README.en.md
@@ -75,7 +75,7 @@ stays in `~/.dsh/memory/`; delete the whole directory manually if you don't need
 Beyond web, the same plugin installs into terminal-shaped hosts:
 
 ```bash
-# dsh-tui (Claude Code style TUI front door — see github.com/ccch1mneyyy/dsh-TUI)
+# dsh-tui (Claude Code style TUI front door — see github.com/ccch1mneyyy/dsh-TUI · site https://dshtui.com)
 dsh plugin --profile dsh-tui add @deepseek-harness-tui/dsh-tui   # first time: create profile + install the TUI host
 dsh plugin --profile dsh-tui add dsh-layered-memory
 dsh --profile dsh-tui

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Agent 应当返回安装结果，并明确告诉你配置中是否已经出现 `
 除 web 外，同一插件可直接装进终端形态宿主：
 
 ```bash
-# dsh-tui（Claude Code 风格 TUI 前门，详见 github.com/ccch1mneyyy/dsh-TUI）
+# dsh-tui（Claude Code 风格 TUI 前门，详见 github.com/ccch1mneyyy/dsh-TUI · 官网 https://dshtui.com）
 dsh plugin --profile dsh-tui add @deepseek-harness-tui/dsh-tui   # 首次：建 profile 并装 TUI 宿主
 dsh plugin --profile dsh-tui add dsh-layered-memory
 dsh --profile dsh-tui

--- a/README.md
+++ b/README.md
@@ -61,6 +61,24 @@ Agent 应当返回安装结果，并明确告诉你配置中是否已经出现 `
 **卸载**：`dsh plugin --profile web remove dsh-layered-memory` + 重启。数据保留在
 `~/.dsh/memory/`，不需要时手动删除整个目录即可。
 
+### 终端形态（TUI / headless）
+
+除 web 外，同一插件可直接装进终端形态宿主：
+
+```bash
+# dsh-tui（Claude Code 风格 TUI 前门，详见 github.com/ccch1mneyyy/dsh-TUI）
+dsh plugin --profile dsh-tui add @deepseek-harness-tui/dsh-tui   # 首次：建 profile 并装 TUI 宿主
+dsh plugin --profile dsh-tui add dsh-layered-memory
+dsh --profile dsh-tui
+```
+
+- **`/memory <auto|chat|work|off>`** 切换当前会话档位，无参数时弹出档位选择面板；
+- **状态行**：提示框上方常驻 `记忆:智能` 等当前档位读数；
+- **`/settings` 设置区块**：总开关、捕获、蒸馏、召回、蒸馏模型路由与输入预算可直接编辑
+  （与 web 设置面板同一存储；复杂路由链仍走 web / YAML）；
+- **headless**（`dsh --profile headless "一次性任务"`）：捕获与蒸馏照常工作，无界面元素。
+  web 与终端形态共享 `~/.dsh/memory/` 同一份记忆。
+
 ### 从源码开发
 
 ```bash
@@ -143,6 +161,8 @@ L1/L2/L3 层级过滤）、层级 × 时间窗口表格（调用数 / 输出与�
   一并停止；`memory_search` 等读工具返回只写提示）。覆盖按会话持久化，切回
   「跟随全局」即清除、跟随自动化区的召回开关；适合调试/评测/敏感会话「只吸收不干扰」。
   与暂停正交：暂停是完全隐身（连捕获都关），只写保留「进」关「出」。
+- **终端形态（TUI）**：同一档位体系在 dsh-tui 宿主下以 `/memory` 命令、状态行与
+  `/settings` 区块呈现（安装见快速开始）。
 
 ## 界面预览
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,6 +38,7 @@ import { SceneStore } from './store/scenes.js';
 import { SessionModeStore } from './store/session-modes.js';
 import { StateStore } from './store/state.js';
 import { registerMemoryTools } from './tools/index.js';
+import { registerTuiSurface } from './tui.js';
 import { errDetail, withFileLog } from './util/filelog.js';
 import { buildRouteChain, resolveModelRoute, invalidateEffortCache } from './llm.js';
 import { effectiveCfg } from './pipeline/runner.js';
@@ -88,6 +89,8 @@ export async function apply(ctx, config) {
             logger.warn(`[memory] 会话档位载入失败（降级为默认档内存态）: ${err instanceof Error ? err.message : String(err)}`);
         }
     }
+    // ── TUI 形态原生接入（dsh-tui/官方 TUI 宿主；软探测，web/headless 下全部 no-op） ──
+    registerTuiSurface(ctx, { logger, live, modes });
     // ── 嵌入源三态（D4：远程/本地/关闭）——状态文件优先于静态配置 ──
     const sourceStore = new EmbeddingSourceStore(dataDir, logger);
     const installer = new RuntimeInstaller(dataDir, PINNED_TRANSFORMERS_VERSION, { logger });

--- a/dist/index.js
+++ b/dist/index.js
@@ -89,8 +89,6 @@ export async function apply(ctx, config) {
             logger.warn(`[memory] 会话档位载入失败（降级为默认档内存态）: ${err instanceof Error ? err.message : String(err)}`);
         }
     }
-    // ── TUI 形态原生接入（dsh-tui/官方 TUI 宿主；软探测，web/headless 下全部 no-op） ──
-    registerTuiSurface(ctx, { logger, live, modes });
     // ── 嵌入源三态（D4：远程/本地/关闭）——状态文件优先于静态配置 ──
     const sourceStore = new EmbeddingSourceStore(dataDir, logger);
     const installer = new RuntimeInstaller(dataDir, PINNED_TRANSFORMERS_VERSION, { logger });
@@ -290,6 +288,9 @@ export async function apply(ctx, config) {
     await runner.init();
     // 档位切换同步（ADR-0003）：切走按捕获档位落袋 / 切 off 挂起 / 切回清挂起
     modes.setModeChangeHandler((sessionId, oldMode, newMode) => runner.onModeChange(sessionId, oldMode, newMode));
+    // ── TUI 形态原生接入（dsh-tui/官方 TUI 宿主；软探测，web/headless 下全部 no-op）。
+    //    放切换链接线之后：/memory 在启动窗口内派发也不会绕过 runner.onModeChange ──
+    registerTuiSurface(ctx, { logger, live, modes });
     // 闲置兜底：静默达标会话的未蒸馏切片自动落袋（idleSeconds=0 关闭）
     runner.startIdleTimer();
     // 重建控制器（存储降级时不建——RPC 端点走 supported=false 分支）

--- a/dist/settings.d.ts
+++ b/dist/settings.d.ts
@@ -37,6 +37,8 @@ export interface LiveSettingsHandle {
     get(): MemoryLiveSettings;
     /** UI 写入入口；不支持时抛错由 RPC 层转成业务错误 */
     update(patch: Partial<MemoryLiveSettings>): Promise<void>;
+    /** 订阅开关变更（TUI 状态行等即时刷新；可选——缺省方退化为下次交互时刷新）。返回退订。 */
+    onChange?(cb: () => void): () => void;
 }
 export declare function liveSettingsSchema(): Schema<MemoryLiveSettings>;
 export declare function registerLiveSettings(ctx: Context, logger: MemoryLogger): LiveSettingsHandle;

--- a/dist/settings.js
+++ b/dist/settings.js
@@ -134,6 +134,9 @@ export function registerLiveSettings(ctx, logger) {
         get: () => ALWAYS_ON,
         update: () => Promise.reject(new Error('settings 服务不可用')),
     };
+    // 变更订阅者（handle.onChange）：挂接在闭包层，inner 换新（服务迁移）后由新 scope 的
+    // watch 继续驱动——订阅方无感
+    const changeCbs = new Set();
     /** 挂接一个（新注册或复用的）scope：重挂前先摘旧 watcher，防跨重启累积。 */
     const wireScope = (scope) => {
         cachedUnwatch?.();
@@ -141,6 +144,14 @@ export function registerLiveSettings(ctx, logger) {
         cachedUnwatch = scope.watch((next) => {
             const prev = current;
             current = resolveSettings(next);
+            for (const cb of changeCbs) {
+                try {
+                    cb();
+                }
+                catch {
+                    // 订阅方异常不阻断开关链（与档位切换回调同纪律）
+                }
+            }
             const b = current.distillBudgets;
             const budgetNote = (b.extract || b.dedup || b.l2 || b.l3)
                 ? `，输出预算=抽取 ${b.extract || '默认'}/去重 ${b.dedup || '默认'}/L2 ${b.l2 || '默认'}/L3 ${b.l3 || '默认'}`
@@ -226,6 +237,12 @@ export function registerLiveSettings(ctx, logger) {
         },
         get: () => inner.get(),
         update: (patch) => inner.update(patch),
+        onChange: (cb) => {
+            changeCbs.add(cb);
+            return () => {
+                changeCbs.delete(cb);
+            };
+        },
     };
 }
 /** scope.get() 的防御性解析：异常值回退全开（宁可多记不可静默停摆）。 */

--- a/dist/tui.d.ts
+++ b/dist/tui.d.ts
@@ -1,0 +1,22 @@
+/**
+ * TUI 形态原生接入（dsh-tui / 官方 TUI 宿主）——软探测、静默降级，绝不拖垮宿主。
+ *
+ * 接缝出处：dsh-ecosystem-spec《终端交互生态插件准入与开发指南》（dsh-TUI 生态）。
+ * web/headless profile 缺这些服务时全部 no-op；服务形状走内联结构类型，不引
+ * 第三方包依赖（与 sessions/connection 的鸭子探测同款纪律——tsc 抓不到运行时
+ * 漂移，升级 dsh-tui 后须真机复验）。
+ * - tuiSettingsSections：/settings 声明式设置区块（settings 命名空间 dsh-memory 的编辑面）；
+ * - tuiStatus：提示框上方键控状态行（当前会话记忆档位；清理是调用者责任，挂 ctx.effect）；
+ * - tuiDialogs：托管单选弹窗（/memory 无参数时的档位选择）；
+ * - commands（dsh-base 服务，全形态存在）：/memory 命令——TUI/web 均可派发，headless 无 UI 自然闲置。
+ */
+import type { Context } from '@deepseek-ai/cordis';
+import type { LiveSettingsHandle } from './settings.js';
+import type { SessionModeStore } from './store/session-modes.js';
+import type { MemoryLogger } from './types.js';
+export interface TuiSurfaceDeps {
+    logger: MemoryLogger;
+    live: LiveSettingsHandle;
+    modes: SessionModeStore;
+}
+export declare function registerTuiSurface(ctx: Context, deps: TuiSurfaceDeps): void;

--- a/dist/tui.js
+++ b/dist/tui.js
@@ -17,7 +17,13 @@ function watchService(ctx, name, attach, logger) {
             const d = attach(svc);
             if (!d)
                 return;
-            disposer?.();
+            // 换实例摘旧：旧 disposer 可能指向已死服务，吞错不阻断新挂接
+            try {
+                disposer?.();
+            }
+            catch {
+                // 旧服务所在宿主行已先一步卸载
+            }
             disposer = d;
             bound = svc;
         }
@@ -65,7 +71,8 @@ export function registerTuiSurface(ctx, deps) {
             if (text === lastText)
                 return;
             lastText = text;
-            status.set('memory', text);
+            // 第三参 identity（插件 ctx）只喂 dsh-tui 的效果台账归属（C-060），省略记 undeclared
+            status.set('memory', text, ctx);
         };
         refreshStatus();
         logger.info('[memory] TUI 状态行已接入（当前会话记忆档位可见）');
@@ -73,6 +80,8 @@ export function registerTuiSurface(ctx, deps) {
             refreshStatus = undefined;
             lastText = '';
             try {
+                // 本插件独占该 key，显式清行与保留 set() 返回的 disposer 语义等价（后者只清
+                // 自己那次写——这里没有并发写者，选更直白的一种）
                 status.set('memory', undefined);
             }
             catch {
@@ -87,6 +96,10 @@ export function registerTuiSurface(ctx, deps) {
         lastSid = sid;
         refreshStatus?.();
     });
+    // 全局开关在 /settings 里被改动 → 状态行即时跟随（否则「记忆:停用」读数要等下次交互才刷新）
+    const unsubscribeLive = live.onChange?.(() => refreshStatus?.());
+    if (unsubscribeLive)
+        ctx.effect(() => () => unsubscribeLive());
     // ── /memory 命令：切当前会话档位；无参数时 TUI 环境弹托管单选 ──
     const MODE_OPTIONS = [
         { id: 'auto', label: '智能', description: '按会话类型自动选 chat/work 族' },
@@ -94,14 +107,16 @@ export function registerTuiSurface(ctx, deps) {
         { id: 'work', label: '工作', description: '团队操作准则（work 族）' },
         { id: 'off', label: '暂停', description: '本会话停用记忆，可随时切回' },
     ];
-    const MODE_USAGE = '用法：/memory <auto|chat|work|off>（无参数时弹出选择）';
+    const MODE_USAGE = '用法：/memory <auto|chat|work|off>';
     watchService(ctx, 'commands', (svc) => {
         const commands = svc;
         const dispose = commands.register({
             name: 'memory',
             description: '切换本会话记忆档位（auto/chat/work/off，无参数弹出选择）',
             handler: async (inv) => {
-                const sid = String(inv.agent?.sessionId ?? '');
+                // 宿主侧 Agent 身份契约是 id（见 CommandsLike 注释）；sessionId 仅作兜底
+                const agentId = inv.agent ?? {};
+                const sid = String(agentId.id ?? agentId.sessionId ?? '');
                 if (!sid)
                     return { kind: 'error', text: '无法确定当前会话' };
                 const arg = inv.rawInput.trim().toLowerCase();

--- a/dist/tui.js
+++ b/dist/tui.js
@@ -1,0 +1,186 @@
+import { EFFORT_CHOICES } from './config.js';
+import { errDetail } from './util/filelog.js';
+/** 状态行/命令回显的档位短名（与 web 芯片「记忆 · 智能」同口径）。 */
+const MODE_LABEL = { auto: '智能', chat: '对话', work: '工作', off: '暂停' };
+/**
+ * 单服务的「现在挂 + internal/service 补挂」：服务晚于本插件就绪（行序 ≠ 发布序）
+ * 或换实例时自动重挂；下线即摘。fiber 卸载统一清理（disposer 指向已死服务时吞错）。
+ */
+function watchService(ctx, name, attach, logger) {
+    let disposer;
+    let bound;
+    const up = () => {
+        const svc = ctx.get?.(name);
+        if (!svc || svc === bound)
+            return;
+        try {
+            const d = attach(svc);
+            if (!d)
+                return;
+            disposer?.();
+            disposer = d;
+            bound = svc;
+        }
+        catch (err) {
+            logger.warn(`[memory] TUI 接缝 ${name} 挂接失败（忽略）: ${errDetail(err)}`);
+        }
+    };
+    const down = () => {
+        try {
+            disposer?.();
+        }
+        catch {
+            // 服务所在宿主行已先一步卸载，残留引用调用必抛——吞掉
+        }
+        disposer = undefined;
+        bound = undefined;
+    };
+    up();
+    ctx.on('internal/service', (n, impl) => {
+        if (n !== name)
+            return;
+        if (impl)
+            up();
+        else if (bound)
+            down();
+    });
+    ctx.effect(() => () => down());
+}
+export function registerTuiSurface(ctx, deps) {
+    const { logger, live, modes } = deps;
+    // ── 状态行：当前会话的记忆档位（TUI 单活动 agent；agent/session-start 覆盖
+    //    /new、/resume、rewind 全部切换路径） ──
+    let lastSid = '';
+    let lastText = '';
+    let refreshStatus;
+    const statusText = () => {
+        if (!live.get().enabled)
+            return '记忆:停用';
+        return `记忆:${MODE_LABEL[modes.get(lastSid)]}`;
+    };
+    watchService(ctx, 'tuiStatus', (svc) => {
+        const status = svc;
+        refreshStatus = () => {
+            const text = statusText();
+            if (text === lastText)
+                return;
+            lastText = text;
+            status.set('memory', text);
+        };
+        refreshStatus();
+        logger.info('[memory] TUI 状态行已接入（当前会话记忆档位可见）');
+        return () => {
+            refreshStatus = undefined;
+            lastText = '';
+            try {
+                status.set('memory', undefined);
+            }
+            catch {
+                // 宿主行已卸载
+            }
+        };
+    }, logger);
+    ctx.on('agent/session-start', (payload) => {
+        const sid = String(payload?.agent?.id ?? '');
+        if (!sid || sid === lastSid)
+            return;
+        lastSid = sid;
+        refreshStatus?.();
+    });
+    // ── /memory 命令：切当前会话档位；无参数时 TUI 环境弹托管单选 ──
+    const MODE_OPTIONS = [
+        { id: 'auto', label: '智能', description: '按会话类型自动选 chat/work 族' },
+        { id: 'chat', label: '对话', description: '用户画像与偏好（chat 族）' },
+        { id: 'work', label: '工作', description: '团队操作准则（work 族）' },
+        { id: 'off', label: '暂停', description: '本会话停用记忆，可随时切回' },
+    ];
+    const MODE_USAGE = '用法：/memory <auto|chat|work|off>（无参数时弹出选择）';
+    watchService(ctx, 'commands', (svc) => {
+        const commands = svc;
+        const dispose = commands.register({
+            name: 'memory',
+            description: '切换本会话记忆档位（auto/chat/work/off，无参数弹出选择）',
+            handler: async (inv) => {
+                const sid = String(inv.agent?.sessionId ?? '');
+                if (!sid)
+                    return { kind: 'error', text: '无法确定当前会话' };
+                const arg = inv.rawInput.trim().toLowerCase();
+                let mode = ['auto', 'chat', 'work', 'off'].includes(arg)
+                    ? arg
+                    : undefined;
+                if (!mode) {
+                    const dialogs = ctx.get?.('tuiDialogs');
+                    if (!dialogs)
+                        return { kind: 'error', text: MODE_USAGE };
+                    const picked = await dialogs.select(ctx, {
+                        title: '记忆档位',
+                        options: MODE_OPTIONS,
+                        timeoutMs: 60_000,
+                        signal: inv.signal,
+                    });
+                    if (!picked)
+                        return { kind: 'success', text: '已取消（档位未变）' };
+                    mode = picked;
+                }
+                const old = modes.get(sid);
+                // ADR-0003 切换链（切走落袋/off 挂起/切回恢复）随 onModeChange 回调自动走
+                modes.set(sid, mode);
+                lastSid = sid;
+                refreshStatus?.();
+                logger.info(`[memory] /memory 切档 session=${sid} ${old}→${mode}`);
+                return { kind: 'success', text: `记忆档位：${MODE_LABEL[old]} → ${MODE_LABEL[mode]}（本会话）` };
+            },
+        });
+        logger.info('[memory] /memory 命令已注册（会话档位切换）');
+        return dispose;
+    }, logger);
+    // ── /settings 设置区块：dsh-memory 命名空间的声明式编辑面（渲染/草稿/保存
+    //    全由 TUI 宿主负责；复杂嵌套键如路由链仍走 YAML/web 面板） ──
+    watchService(ctx, 'tuiSettingsSections', (svc) => {
+        const sections = svc;
+        const dispose = sections.register({
+            ns: 'dsh-memory',
+            title: 'Layered Memory',
+            descriptions: { zh: '分层蒸馏记忆' },
+            fields: [
+                { path: ['enabled'], label: 'Master switch', descriptions: { zh: '总开关（关闭即全停）' }, kind: 'boolean' },
+                { path: ['capture'], label: 'Capture', descriptions: { zh: '捕获（L0 对话留档）' }, kind: 'boolean' },
+                { path: ['distill'], label: 'Distill', descriptions: { zh: '蒸馏（L1~L3 记忆整理）' }, kind: 'boolean' },
+                { path: ['recall'], label: 'Recall injection', descriptions: { zh: '召回注入' }, kind: 'boolean' },
+                {
+                    path: ['reasoningEffort'],
+                    label: 'Distill reasoning effort',
+                    descriptions: { zh: '蒸馏思考档位' },
+                    kind: 'select',
+                    options: EFFORT_CHOICES.map((e) => ({ value: e, label: e === '' ? 'follow config' : e })),
+                },
+                {
+                    path: ['distillProvider'],
+                    label: 'Distill provider',
+                    descriptions: { zh: '蒸馏模型供应商' },
+                    kind: 'text',
+                    hint: 'Empty = follow default model',
+                    hintDescriptions: { zh: '留空跟随默认模型' },
+                },
+                {
+                    path: ['distillModel'],
+                    label: 'Distill model',
+                    descriptions: { zh: '蒸馏模型' },
+                    kind: 'text',
+                    hint: 'Empty = follow default model',
+                    hintDescriptions: { zh: '留空跟随默认模型' },
+                },
+                {
+                    path: ['distillMaxInputChars'],
+                    label: 'Distill input budget',
+                    descriptions: { zh: '蒸馏输入预算（字符）' },
+                    kind: 'number',
+                    hint: '0 = default',
+                    hintDescriptions: { zh: '0 = 默认' },
+                },
+            ],
+        });
+        logger.info('[memory] TUI 设置区块已注册（/settings · 分层蒸馏记忆）');
+        return dispose;
+    }, logger);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-layered-memory",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "L0~L3 分层蒸馏记忆插件 for DeepSeek Harness：自动捕获对话（L0）、抽取原子记忆（L1）、整合场景块（L2）、蒸馏核心画像/团队方法论（L3），并在模型步骤前自动召回注入。移植自 MemoryCore (TencentDB Agent Memory) 的管线设计。",
   "type": "module",
   "main": "dist/index.js",

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -21,6 +21,11 @@
   明细（模块级单例 + init 注入 db；按 model 分组、持久化保留期默认 365 天，面向 UI 成本看板）。
 - `settings.ts` — 记忆模式运行时开关（官方 settings 服务命名空间 `dsh-memory`，live 生效；
   见下方不变量「记忆模式开关」）。
+- `tui.ts` — TUI 形态原生接入（dsh-tui/官方 TUI 宿主，0.11.0）：tuiStatus 状态行 /
+  `/memory` 命令（commands 是 **base 服务，全形态注册**）/ tuiSettingsSections 设置区块；
+  三接缝全部软探测（先 `ctx.get` + `internal/service` 晚就绪补挂 + 下线摘挂接），web/headless
+  下 no-op。服务形状是内联结构类型（鸭子探测，不引 dsh-tui 依赖）——升级 dsh-tui 后须真机
+  复验。设置区块字段只支持标量 kind（text/number/boolean/select），路由链等嵌套键不声明。
 - `hooks/capture.ts` — L0 捕获（session/event turn/end，清洗去噪后落盘 JSONL）。
 - `hooks/recall.ts` — **消息侧注入**（ADR-0001）：pre-step prepend 注册、先 next() 再
   在消息列表头部插入 `form:'recall'` 合成消息（排在用户新消息之前）；agent 作用域上下文

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import { SceneStore } from './store/scenes.js';
 import { SessionModeStore } from './store/session-modes.js';
 import { StateStore } from './store/state.js';
 import { registerMemoryTools } from './tools/index.js';
+import { registerTuiSurface } from './tui.js';
 import type { MemoryLogger } from './types.js';
 import { errDetail, withFileLog } from './util/filelog.js';
 import { buildRouteChain, resolveModelRoute, invalidateEffortCache } from './llm.js';
@@ -106,6 +107,9 @@ export async function apply(ctx: Context, config: MemoryConfig): Promise<void> {
       logger.warn(`[memory] 会话档位载入失败（降级为默认档内存态）: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
+
+  // ── TUI 形态原生接入（dsh-tui/官方 TUI 宿主；软探测，web/headless 下全部 no-op） ──
+  registerTuiSurface(ctx, { logger, live, modes });
 
   // ── 嵌入源三态（D4：远程/本地/关闭）——状态文件优先于静态配置 ──
   const sourceStore = new EmbeddingSourceStore(dataDir, logger);

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,9 +108,6 @@ export async function apply(ctx: Context, config: MemoryConfig): Promise<void> {
     }
   }
 
-  // ── TUI 形态原生接入（dsh-tui/官方 TUI 宿主；软探测，web/headless 下全部 no-op） ──
-  registerTuiSurface(ctx, { logger, live, modes });
-
   // ── 嵌入源三态（D4：远程/本地/关闭）——状态文件优先于静态配置 ──
   const sourceStore = new EmbeddingSourceStore(dataDir, logger);
   const installer = new RuntimeInstaller(dataDir, PINNED_TRANSFORMERS_VERSION, { logger });
@@ -324,6 +321,9 @@ export async function apply(ctx: Context, config: MemoryConfig): Promise<void> {
   await runner.init();
   // 档位切换同步（ADR-0003）：切走按捕获档位落袋 / 切 off 挂起 / 切回清挂起
   modes.setModeChangeHandler((sessionId, oldMode, newMode) => runner.onModeChange(sessionId, oldMode, newMode));
+  // ── TUI 形态原生接入（dsh-tui/官方 TUI 宿主；软探测，web/headless 下全部 no-op）。
+  //    放切换链接线之后：/memory 在启动窗口内派发也不会绕过 runner.onModeChange ──
+  registerTuiSurface(ctx, { logger, live, modes });
   // 闲置兜底：静默达标会话的未蒸馏切片自动落袋（idleSeconds=0 关闭）
   runner.startIdleTimer();
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -82,6 +82,8 @@ export interface LiveSettingsHandle {
   get(): MemoryLiveSettings;
   /** UI 写入入口；不支持时抛错由 RPC 层转成业务错误 */
   update(patch: Partial<MemoryLiveSettings>): Promise<void>;
+  /** 订阅开关变更（TUI 状态行等即时刷新；可选——缺省方退化为下次交互时刷新）。返回退订。 */
+  onChange?(cb: () => void): () => void;
 }
 
 // 0.1.2-alpha 起 dsh-settings 不再导出 settingsNamespace 品牌 helper：
@@ -160,6 +162,9 @@ export function registerLiveSettings(ctx: Context, logger: MemoryLogger): LiveSe
     get: () => ALWAYS_ON,
     update: () => Promise.reject(new Error('settings 服务不可用')),
   };
+  // 变更订阅者（handle.onChange）：挂接在闭包层，inner 换新（服务迁移）后由新 scope 的
+  // watch 继续驱动——订阅方无感
+  const changeCbs = new Set<() => void>();
 
   /** 挂接一个（新注册或复用的）scope：重挂前先摘旧 watcher，防跨重启累积。 */
   const wireScope = (scope: SettingsScope<MemoryLiveSettings>): LiveSettingsHandle => {
@@ -168,6 +173,13 @@ export function registerLiveSettings(ctx: Context, logger: MemoryLogger): LiveSe
     cachedUnwatch = scope.watch((next) => {
       const prev = current;
       current = resolveSettings(next);
+      for (const cb of changeCbs) {
+        try {
+          cb();
+        } catch {
+          // 订阅方异常不阻断开关链（与档位切换回调同纪律）
+        }
+      }
       const b = current.distillBudgets;
       const budgetNote = (b.extract || b.dedup || b.l2 || b.l3)
         ? `，输出预算=抽取 ${b.extract || '默认'}/去重 ${b.dedup || '默认'}/L2 ${b.l2 || '默认'}/L3 ${b.l3 || '默认'}`
@@ -258,6 +270,12 @@ export function registerLiveSettings(ctx: Context, logger: MemoryLogger): LiveSe
     },
     get: (): MemoryLiveSettings => inner.get(),
     update: (patch: Partial<MemoryLiveSettings>): Promise<void> => inner.update(patch),
+    onChange: (cb: () => void): (() => void) => {
+      changeCbs.add(cb);
+      return () => {
+        changeCbs.delete(cb);
+      };
+    },
   };
 }
 

--- a/src/smoke.ts
+++ b/src/smoke.ts
@@ -4010,6 +4010,10 @@ async function main(): Promise<void> {
     try {
       const modes = new SessionModeStore(tmp34, 'auto', silentLogger);
       let liveOn = true;
+      const liveCbs = new Set<() => void>();
+      const notifyLive = (): void => {
+        for (const cb of liveCbs) cb();
+      };
       const live: LiveSettingsHandle = {
         supported: true,
         get: () => ({
@@ -4026,6 +4030,12 @@ async function main(): Promise<void> {
           distillMaxInputChars: 0,
         }),
         update: async () => {},
+        onChange: (cb: () => void) => {
+          liveCbs.add(cb);
+          return () => {
+            liveCbs.delete(cb);
+          };
+        },
       };
 
       // fake ctx：服务槽 + 事件监听 + effect 收集（与 16 节同款惯例）
@@ -4086,8 +4096,12 @@ async function main(): Promise<void> {
           return selectImpl!();
         },
       };
-      const mkInv = (sessionId: string, rawInput: string): { agent: { sessionId: string }; rawInput: string; signal: AbortSignal } => ({
-        agent: { sessionId },
+      const mkInv = (
+        sessionId: string,
+        rawInput: string,
+        agentKey: 'id' | 'sessionId' = 'id',
+      ): { agent: { id?: string; sessionId?: string }; rawInput: string; signal: AbortSignal } => ({
+        agent: { [agentKey]: sessionId },
         rawInput,
         signal: new AbortController().signal,
       });
@@ -4108,7 +4122,7 @@ async function main(): Promise<void> {
       fire('agent/session-start', { agent: { id: 's34-b' } });
       assert(statusSets.at(-1)?.[1] === '记忆:暂停', '会话切换后状态行跟随档位（off → 记忆:暂停）');
 
-      // 34d /memory 参数路径：切档 + 回执 + 状态行同步
+      // 34d /memory 参数路径：切档 + 回执 + 状态行同步（agent.id 是宿主契约字段）
       services.set('commands', commands);
       fire('internal/service', 'commands', commands);
       assert(commandDef?.name === 'memory', '命令服务上线即注册 /memory');
@@ -4116,6 +4130,8 @@ async function main(): Promise<void> {
       assert(r1.kind === 'success' && r1.text?.includes('工作') === true, '/memory work 回执成功文案');
       assert(modes.get('s34-b') === 'work', '/memory work 写穿档位存储');
       assert(statusSets.at(-1)?.[1] === '记忆:工作', '切档后状态行即时刷新（记忆:工作）');
+      const r1b = await commandDef!.handler(mkInv('s34-d', 'chat', 'sessionId'));
+      assert(r1b.kind === 'success' && modes.get('s34-d') === 'chat', 'sessionId 形状兜底同样落档');
 
       // 34e 非法参数且无弹窗服务 → 用法错误（web 形态同路径）
       const r2 = await commandDef!.handler(mkInv('s34-b', 'bogus'));
@@ -4132,10 +4148,13 @@ async function main(): Promise<void> {
       const r4 = await commandDef!.handler(mkInv('s34-c', ''));
       assert(r4.kind === 'success' && r4.text?.includes('已取消') === true && modes.get('s34-c') === 'chat', '弹窗取消档位不变');
 
-      // 34g 全局开关关闭：任何档位显示停用（状态行跟随 live 读数）
+      // 34g 全局开关关闭：任何档位显示停用（状态行跟随 live 读数）——两条触发路径都验
       liveOn = false;
       await commandDef!.handler(mkInv('s34-c', 'auto'));
       assert(statusSets.at(-1)?.[1] === '记忆:停用', '总开关关闭时状态行显示记忆:停用');
+      liveOn = true;
+      notifyLive();
+      assert(statusSets.at(-1)?.[1] === '记忆:智能', 'live.onChange 变更广播即时刷新状态行');
 
       // 34h 设置区块：ns 与字段覆盖
       services.set('tuiSettingsSections', sectionsSvc);
@@ -4155,6 +4174,19 @@ async function main(): Promise<void> {
       // 34i 服务下线：摘挂接并清状态行
       fire('internal/service', 'tuiStatus', undefined);
       assert(statusSets.at(-1)?.[0] === 'memory' && statusSets.at(-1)?.[1] === undefined, 'tuiStatus 下线即清行');
+
+      // 34i' 服务换实例重挂：新对象上线 → 重挂接并刷新（svc !== bound 分支）
+      const tuiStatus2 = {
+        set: (k: string, t: string | undefined) => {
+          statusSets.push([k, t]);
+          return () => {
+            statusSets.push([k, undefined]);
+          };
+        },
+      };
+      services.set('tuiStatus', tuiStatus2);
+      fire('internal/service', 'tuiStatus', tuiStatus2);
+      assert(statusSets.at(-1)?.[1] === '记忆:智能', '服务换实例自动重挂（新实例接管状态行）');
 
       // 34j fiber 卸载：全部 disposer 可跑不抛
       let disposedOk = true;

--- a/src/smoke.ts
+++ b/src/smoke.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 import { Worker } from 'node:worker_threads';
 import type { SessionEvent } from '@deepseek-ai/dsh-session';
 import type { MemoryConfig } from './config.js';
-import { memorySchema } from './config.js';
+import { EFFORT_CHOICES, memorySchema } from './config.js';
 import { EmbedHelper, NoopEmbeddingService, type EmbeddingService } from './store/embedding.js';
 import { applyRecallBudget, raceRecallTimeout, RECALL_TRUNCATION_SUFFIX, truncateRecallLine } from './util/recall-budget.js';
 import {
@@ -76,6 +76,7 @@ import { formatExtractionPrompt, getExtractMemoriesSystemPrompt } from './prompt
 import { formatBatchConflictPrompt, getConflictDetectionSystemPrompt } from './prompts/l1-dedup.js';
 import { buildScenePrompt, formatSceneSummaries } from './prompts/scene.js';
 import { buildPersonaPrompt } from './prompts/persona.js';
+import { registerTuiSurface } from './tui.js';
 import { blocksToText, tokenize } from './util/text.js';
 import { tokenizerStamp } from './util/tokenizer.js';
 
@@ -3999,6 +4000,174 @@ async function main(): Promise<void> {
       }
     } finally {
       await fs.rm(tmp33, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  // ── 34. TUI 形态原生接入：状态行 / /memory 命令 / 设置区块（软探测 + 晚就绪补挂 + 下线清理） ──
+  console.log('== 34. TUI 形态原生接入（tui.ts） ==');
+  {
+    const tmp34 = await fs.mkdtemp(path.join(os.tmpdir(), 'dsh-mem-tui-'));
+    try {
+      const modes = new SessionModeStore(tmp34, 'auto', silentLogger);
+      let liveOn = true;
+      const live: LiveSettingsHandle = {
+        supported: true,
+        get: () => ({
+          enabled: liveOn,
+          capture: true,
+          distill: true,
+          recall: true,
+          reasoningEffort: '',
+          distillProvider: '',
+          distillModel: '',
+          distillChain: [],
+          distillLayerChains: { l1: [], l2: [], l3: [] },
+          distillBudgets: { extract: 0, dedup: 0, l2: 0, l3: 0 },
+          distillMaxInputChars: 0,
+        }),
+        update: async () => {},
+      };
+
+      // fake ctx：服务槽 + 事件监听 + effect 收集（与 16 节同款惯例）
+      type Handler = (...args: unknown[]) => void;
+      const services = new Map<string, unknown>();
+      const listeners = new Map<string, Set<Handler>>();
+      const disposers: Array<() => void> = [];
+      const ctx = {
+        get: (n: string) => services.get(n),
+        on: (e: string, h: Handler) => {
+          if (!listeners.has(e)) listeners.set(e, new Set());
+          listeners.get(e)!.add(h);
+          return () => {
+            listeners.get(e)?.delete(h);
+          };
+        },
+        effect: (f: () => (() => void)) => {
+          const d = f();
+          disposers.push(d);
+          return d;
+        },
+      } as never;
+      const fire = (e: string, ...args: unknown[]): void => {
+        for (const h of listeners.get(e) ?? []) h(...args);
+      };
+
+      // fake TUI 接缝服务
+      const statusSets: Array<[string, string | undefined]> = [];
+      const tuiStatus = {
+        set: (k: string, t: string | undefined) => {
+          statusSets.push([k, t]);
+          return () => {
+            statusSets.push([k, undefined]);
+          };
+        },
+      };
+      let commandDef: { name: string; handler: (inv: unknown) => Promise<{ kind: string; text?: string }> } | undefined;
+      const commands = {
+        register: (d: { name: string; handler: (inv: unknown) => Promise<{ kind: string; text?: string }> }) => {
+          commandDef = d;
+          return () => {
+            commandDef = undefined;
+          };
+        },
+      };
+      const sectionDefs: Array<{ ns: string; fields: Array<{ path: readonly string[]; kind: string; options?: unknown[] }> }> = [];
+      const sectionsSvc = {
+        register: (s: { ns: string; fields: Array<{ path: readonly string[]; kind: string; options?: unknown[] }> }) => {
+          sectionDefs.push(s);
+          return () => {};
+        },
+      };
+      let selectImpl: (() => Promise<string | undefined>) | undefined;
+      let selectReq: { title?: string; options?: unknown[] } | undefined;
+      const dialogsSvc = {
+        select: async (_owner: unknown, req: { title?: string; options?: unknown[] }) => {
+          selectReq = req;
+          return selectImpl!();
+        },
+      };
+      const mkInv = (sessionId: string, rawInput: string): { agent: { sessionId: string }; rawInput: string; signal: AbortSignal } => ({
+        agent: { sessionId },
+        rawInput,
+        signal: new AbortController().signal,
+      });
+
+      // 34a 无任何 TUI 服务（web/headless 形态）：不抛、不注册命令
+      registerTuiSurface(ctx, { logger: silentLogger, live, modes });
+      assert(commandDef === undefined, '无 TUI 服务时零注册（web/headless no-op）');
+
+      // 34b 状态行晚就绪补挂：internal/service 上线后接入，默认档文案
+      services.set('tuiStatus', tuiStatus);
+      fire('internal/service', 'tuiStatus', tuiStatus);
+      assert(statusSets.at(-1)?.[0] === 'memory' && statusSets.at(-1)?.[1] === '记忆:智能', '状态行接入即显示默认档（记忆:智能）');
+      fire('internal/service', 'tuiStatus', tuiStatus);
+      assert(statusSets.length === 1, '同实例重复上线事件不重复挂接（幂等）');
+
+      // 34c 会话切换刷新：agent/session-start → 新会话档位上屏
+      modes.set('s34-b', 'off');
+      fire('agent/session-start', { agent: { id: 's34-b' } });
+      assert(statusSets.at(-1)?.[1] === '记忆:暂停', '会话切换后状态行跟随档位（off → 记忆:暂停）');
+
+      // 34d /memory 参数路径：切档 + 回执 + 状态行同步
+      services.set('commands', commands);
+      fire('internal/service', 'commands', commands);
+      assert(commandDef?.name === 'memory', '命令服务上线即注册 /memory');
+      const r1 = await commandDef!.handler(mkInv('s34-b', ' Work '));
+      assert(r1.kind === 'success' && r1.text?.includes('工作') === true, '/memory work 回执成功文案');
+      assert(modes.get('s34-b') === 'work', '/memory work 写穿档位存储');
+      assert(statusSets.at(-1)?.[1] === '记忆:工作', '切档后状态行即时刷新（记忆:工作）');
+
+      // 34e 非法参数且无弹窗服务 → 用法错误（web 形态同路径）
+      const r2 = await commandDef!.handler(mkInv('s34-b', 'bogus'));
+      assert(r2.kind === 'error' && r2.text?.includes('用法') === true, '非法参数无弹窗时回用法错误');
+
+      // 34f 无参数 + 弹窗服务：选择落档 / 取消不变
+      services.set('tuiDialogs', dialogsSvc);
+      fire('internal/service', 'tuiDialogs', dialogsSvc);
+      selectImpl = async () => 'chat';
+      const r3 = await commandDef!.handler(mkInv('s34-c', ''));
+      assert(r3.kind === 'success' && modes.get('s34-c') === 'chat', '/memory 无参数弹窗选择落档（chat）');
+      assert(selectReq?.title === '记忆档位' && selectReq?.options?.length === 4, '弹窗请求形状（标题 + 四选项）');
+      selectImpl = async () => undefined;
+      const r4 = await commandDef!.handler(mkInv('s34-c', ''));
+      assert(r4.kind === 'success' && r4.text?.includes('已取消') === true && modes.get('s34-c') === 'chat', '弹窗取消档位不变');
+
+      // 34g 全局开关关闭：任何档位显示停用（状态行跟随 live 读数）
+      liveOn = false;
+      await commandDef!.handler(mkInv('s34-c', 'auto'));
+      assert(statusSets.at(-1)?.[1] === '记忆:停用', '总开关关闭时状态行显示记忆:停用');
+
+      // 34h 设置区块：ns 与字段覆盖
+      services.set('tuiSettingsSections', sectionsSvc);
+      fire('internal/service', 'tuiSettingsSections', sectionsSvc);
+      assert(sectionDefs.length === 1 && sectionDefs[0].ns === 'dsh-memory', '设置区块注册到 dsh-memory 命名空间');
+      const paths34 = sectionDefs[0].fields.map((f) => f.path.join('.')).sort().join(',');
+      assert(
+        paths34 ===
+          ['enabled', 'capture', 'distill', 'recall', 'reasoningEffort', 'distillProvider', 'distillModel', 'distillMaxInputChars']
+            .sort()
+            .join(','),
+        '设置区块字段覆盖运行时开关 + 蒸馏路由/预算',
+      );
+      const effortField = sectionDefs[0].fields.find((f) => f.path[0] === 'reasoningEffort');
+      assert(effortField?.options?.length === EFFORT_CHOICES.length, '思考档位选项与 EFFORT_CHOICES 对齐');
+
+      // 34i 服务下线：摘挂接并清状态行
+      fire('internal/service', 'tuiStatus', undefined);
+      assert(statusSets.at(-1)?.[0] === 'memory' && statusSets.at(-1)?.[1] === undefined, 'tuiStatus 下线即清行');
+
+      // 34j fiber 卸载：全部 disposer 可跑不抛
+      let disposedOk = true;
+      for (const d of disposers) {
+        try {
+          d();
+        } catch {
+          disposedOk = false;
+        }
+      }
+      assert(disposedOk, 'fiber 卸载清理不抛');
+    } finally {
+      await fs.rm(tmp34, { recursive: true, force: true }).catch(() => {});
     }
   }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -40,13 +40,16 @@ interface TuiSettingsSectionsLike {
   register(section: unknown): () => void;
 }
 
-/** dsh-commands 的最小面（@deepseek-ai/dsh-commands CommandDefinition/CommandResult）。 */
+/** dsh-commands 的最小面（@deepseek-ai/dsh-commands CommandDefinition/CommandResult）。
+ *  invocation.agent 是宿主侧活 Agent——身份字段契约是 `id`（dsh-agent types.d.ts：
+ *  `Agent { readonly id: SessionId }`）；`sessionId` 是工厂入参 CreateAgentOptions 的
+ *  字段、不在 Agent 上（0.11.0 首版读错被审查抓出）。作兜底同时接受两者。 */
 interface CommandsLike {
   register(definition: {
     name: string;
     description: string;
     handler: (
-      invocation: { agent: { sessionId: unknown }; rawInput: string; signal: AbortSignal },
+      invocation: { agent: { id?: unknown; sessionId?: unknown }; rawInput: string; signal: AbortSignal },
     ) =>
       | { kind: 'success'; text?: string }
       | { kind: 'error'; text: string }
@@ -72,7 +75,12 @@ function watchService(
     try {
       const d = attach(svc);
       if (!d) return;
-      disposer?.();
+      // 换实例摘旧：旧 disposer 可能指向已死服务，吞错不阻断新挂接
+      try {
+        disposer?.();
+      } catch {
+        // 旧服务所在宿主行已先一步卸载
+      }
       disposer = d;
       bound = svc;
     } catch (err) {
@@ -124,7 +132,8 @@ export function registerTuiSurface(ctx: Context, deps: TuiSurfaceDeps): void {
         const text = statusText();
         if (text === lastText) return;
         lastText = text;
-        status.set('memory', text);
+        // 第三参 identity（插件 ctx）只喂 dsh-tui 的效果台账归属（C-060），省略记 undeclared
+        status.set('memory', text, ctx);
       };
       refreshStatus();
       logger.info('[memory] TUI 状态行已接入（当前会话记忆档位可见）');
@@ -132,6 +141,8 @@ export function registerTuiSurface(ctx: Context, deps: TuiSurfaceDeps): void {
         refreshStatus = undefined;
         lastText = '';
         try {
+          // 本插件独占该 key，显式清行与保留 set() 返回的 disposer 语义等价（后者只清
+          // 自己那次写——这里没有并发写者，选更直白的一种）
           status.set('memory', undefined);
         } catch {
           // 宿主行已卸载
@@ -146,6 +157,9 @@ export function registerTuiSurface(ctx: Context, deps: TuiSurfaceDeps): void {
     lastSid = sid;
     refreshStatus?.();
   });
+  // 全局开关在 /settings 里被改动 → 状态行即时跟随（否则「记忆:停用」读数要等下次交互才刷新）
+  const unsubscribeLive = live.onChange?.(() => refreshStatus?.());
+  if (unsubscribeLive) ctx.effect(() => () => unsubscribeLive());
 
   // ── /memory 命令：切当前会话档位；无参数时 TUI 环境弹托管单选 ──
   const MODE_OPTIONS: readonly { id: MemoryMode; label: string; description: string }[] = [
@@ -154,7 +168,7 @@ export function registerTuiSurface(ctx: Context, deps: TuiSurfaceDeps): void {
     { id: 'work', label: '工作', description: '团队操作准则（work 族）' },
     { id: 'off', label: '暂停', description: '本会话停用记忆，可随时切回' },
   ];
-  const MODE_USAGE = '用法：/memory <auto|chat|work|off>（无参数时弹出选择）';
+  const MODE_USAGE = '用法：/memory <auto|chat|work|off>';
   watchService(
     ctx,
     'commands',
@@ -164,7 +178,9 @@ export function registerTuiSurface(ctx: Context, deps: TuiSurfaceDeps): void {
         name: 'memory',
         description: '切换本会话记忆档位（auto/chat/work/off，无参数弹出选择）',
         handler: async (inv) => {
-          const sid = String((inv.agent as { sessionId?: unknown } | undefined)?.sessionId ?? '');
+          // 宿主侧 Agent 身份契约是 id（见 CommandsLike 注释）；sessionId 仅作兜底
+          const agentId = (inv.agent as { id?: unknown; sessionId?: unknown } | undefined) ?? {};
+          const sid = String(agentId.id ?? agentId.sessionId ?? '');
           if (!sid) return { kind: 'error', text: '无法确定当前会话' };
           const arg = inv.rawInput.trim().toLowerCase();
           let mode: MemoryMode | undefined = (

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -1,0 +1,256 @@
+/**
+ * TUI 形态原生接入（dsh-tui / 官方 TUI 宿主）——软探测、静默降级，绝不拖垮宿主。
+ *
+ * 接缝出处：dsh-ecosystem-spec《终端交互生态插件准入与开发指南》（dsh-TUI 生态）。
+ * web/headless profile 缺这些服务时全部 no-op；服务形状走内联结构类型，不引
+ * 第三方包依赖（与 sessions/connection 的鸭子探测同款纪律——tsc 抓不到运行时
+ * 漂移，升级 dsh-tui 后须真机复验）。
+ * - tuiSettingsSections：/settings 声明式设置区块（settings 命名空间 dsh-memory 的编辑面）；
+ * - tuiStatus：提示框上方键控状态行（当前会话记忆档位；清理是调用者责任，挂 ctx.effect）；
+ * - tuiDialogs：托管单选弹窗（/memory 无参数时的档位选择）；
+ * - commands（dsh-base 服务，全形态存在）：/memory 命令——TUI/web 均可派发，headless 无 UI 自然闲置。
+ */
+import type { Context } from '@deepseek-ai/cordis';
+import { EFFORT_CHOICES } from './config.js';
+import type { LiveSettingsHandle } from './settings.js';
+import type { SessionModeStore } from './store/session-modes.js';
+import type { MemoryLogger, MemoryMode } from './types.js';
+import { errDetail } from './util/filelog.js';
+
+/** 状态行/命令回显的档位短名（与 web 芯片「记忆 · 智能」同口径）。 */
+const MODE_LABEL: Record<MemoryMode, string> = { auto: '智能', chat: '对话', work: '工作', off: '暂停' };
+
+interface TuiStatusLike {
+  set(key: string, text: string | number | boolean | undefined, identity?: unknown): () => void;
+}
+
+interface TuiDialogsLike {
+  select(
+    owner: unknown,
+    request: {
+      title: string;
+      options: readonly { id: string; label: string; description?: string }[];
+      timeoutMs?: number;
+      signal?: AbortSignal;
+    },
+  ): Promise<string | undefined>;
+}
+
+interface TuiSettingsSectionsLike {
+  register(section: unknown): () => void;
+}
+
+/** dsh-commands 的最小面（@deepseek-ai/dsh-commands CommandDefinition/CommandResult）。 */
+interface CommandsLike {
+  register(definition: {
+    name: string;
+    description: string;
+    handler: (
+      invocation: { agent: { sessionId: unknown }; rawInput: string; signal: AbortSignal },
+    ) =>
+      | { kind: 'success'; text?: string }
+      | { kind: 'error'; text: string }
+      | Promise<{ kind: 'success'; text?: string } | { kind: 'error'; text: string }>;
+  }): () => void;
+}
+
+/**
+ * 单服务的「现在挂 + internal/service 补挂」：服务晚于本插件就绪（行序 ≠ 发布序）
+ * 或换实例时自动重挂；下线即摘。fiber 卸载统一清理（disposer 指向已死服务时吞错）。
+ */
+function watchService(
+  ctx: Context,
+  name: string,
+  attach: (svc: unknown) => (() => void) | undefined,
+  logger: MemoryLogger,
+): void {
+  let disposer: (() => void) | undefined;
+  let bound: unknown;
+  const up = (): void => {
+    const svc = ctx.get?.(name);
+    if (!svc || svc === bound) return;
+    try {
+      const d = attach(svc);
+      if (!d) return;
+      disposer?.();
+      disposer = d;
+      bound = svc;
+    } catch (err) {
+      logger.warn(`[memory] TUI 接缝 ${name} 挂接失败（忽略）: ${errDetail(err)}`);
+    }
+  };
+  const down = (): void => {
+    try {
+      disposer?.();
+    } catch {
+      // 服务所在宿主行已先一步卸载，残留引用调用必抛——吞掉
+    }
+    disposer = undefined;
+    bound = undefined;
+  };
+  up();
+  ctx.on('internal/service', (n: string, impl: unknown) => {
+    if (n !== name) return;
+    if (impl) up();
+    else if (bound) down();
+  });
+  ctx.effect(() => () => down());
+}
+
+export interface TuiSurfaceDeps {
+  logger: MemoryLogger;
+  live: LiveSettingsHandle;
+  modes: SessionModeStore;
+}
+
+export function registerTuiSurface(ctx: Context, deps: TuiSurfaceDeps): void {
+  const { logger, live, modes } = deps;
+
+  // ── 状态行：当前会话的记忆档位（TUI 单活动 agent；agent/session-start 覆盖
+  //    /new、/resume、rewind 全部切换路径） ──
+  let lastSid = '';
+  let lastText = '';
+  let refreshStatus: (() => void) | undefined;
+  const statusText = (): string => {
+    if (!live.get().enabled) return '记忆:停用';
+    return `记忆:${MODE_LABEL[modes.get(lastSid)]}`;
+  };
+  watchService(
+    ctx,
+    'tuiStatus',
+    (svc) => {
+      const status = svc as TuiStatusLike;
+      refreshStatus = () => {
+        const text = statusText();
+        if (text === lastText) return;
+        lastText = text;
+        status.set('memory', text);
+      };
+      refreshStatus();
+      logger.info('[memory] TUI 状态行已接入（当前会话记忆档位可见）');
+      return () => {
+        refreshStatus = undefined;
+        lastText = '';
+        try {
+          status.set('memory', undefined);
+        } catch {
+          // 宿主行已卸载
+        }
+      };
+    },
+    logger,
+  );
+  ctx.on('agent/session-start', (payload: { agent?: { id?: unknown } }) => {
+    const sid = String(payload?.agent?.id ?? '');
+    if (!sid || sid === lastSid) return;
+    lastSid = sid;
+    refreshStatus?.();
+  });
+
+  // ── /memory 命令：切当前会话档位；无参数时 TUI 环境弹托管单选 ──
+  const MODE_OPTIONS: readonly { id: MemoryMode; label: string; description: string }[] = [
+    { id: 'auto', label: '智能', description: '按会话类型自动选 chat/work 族' },
+    { id: 'chat', label: '对话', description: '用户画像与偏好（chat 族）' },
+    { id: 'work', label: '工作', description: '团队操作准则（work 族）' },
+    { id: 'off', label: '暂停', description: '本会话停用记忆，可随时切回' },
+  ];
+  const MODE_USAGE = '用法：/memory <auto|chat|work|off>（无参数时弹出选择）';
+  watchService(
+    ctx,
+    'commands',
+    (svc) => {
+      const commands = svc as CommandsLike;
+      const dispose = commands.register({
+        name: 'memory',
+        description: '切换本会话记忆档位（auto/chat/work/off，无参数弹出选择）',
+        handler: async (inv) => {
+          const sid = String((inv.agent as { sessionId?: unknown } | undefined)?.sessionId ?? '');
+          if (!sid) return { kind: 'error', text: '无法确定当前会话' };
+          const arg = inv.rawInput.trim().toLowerCase();
+          let mode: MemoryMode | undefined = (
+            ['auto', 'chat', 'work', 'off'] as readonly MemoryMode[]
+          ).includes(arg as MemoryMode)
+            ? (arg as MemoryMode)
+            : undefined;
+          if (!mode) {
+            const dialogs = ctx.get?.('tuiDialogs') as TuiDialogsLike | undefined;
+            if (!dialogs) return { kind: 'error', text: MODE_USAGE };
+            const picked = await dialogs.select(ctx, {
+              title: '记忆档位',
+              options: MODE_OPTIONS,
+              timeoutMs: 60_000,
+              signal: inv.signal,
+            });
+            if (!picked) return { kind: 'success', text: '已取消（档位未变）' };
+            mode = picked as MemoryMode;
+          }
+          const old = modes.get(sid);
+          // ADR-0003 切换链（切走落袋/off 挂起/切回恢复）随 onModeChange 回调自动走
+          modes.set(sid, mode);
+          lastSid = sid;
+          refreshStatus?.();
+          logger.info(`[memory] /memory 切档 session=${sid} ${old}→${mode}`);
+          return { kind: 'success', text: `记忆档位：${MODE_LABEL[old]} → ${MODE_LABEL[mode]}（本会话）` };
+        },
+      });
+      logger.info('[memory] /memory 命令已注册（会话档位切换）');
+      return dispose;
+    },
+    logger,
+  );
+
+  // ── /settings 设置区块：dsh-memory 命名空间的声明式编辑面（渲染/草稿/保存
+  //    全由 TUI 宿主负责；复杂嵌套键如路由链仍走 YAML/web 面板） ──
+  watchService(
+    ctx,
+    'tuiSettingsSections',
+    (svc) => {
+      const sections = svc as TuiSettingsSectionsLike;
+      const dispose = sections.register({
+        ns: 'dsh-memory',
+        title: 'Layered Memory',
+        descriptions: { zh: '分层蒸馏记忆' },
+        fields: [
+          { path: ['enabled'], label: 'Master switch', descriptions: { zh: '总开关（关闭即全停）' }, kind: 'boolean' },
+          { path: ['capture'], label: 'Capture', descriptions: { zh: '捕获（L0 对话留档）' }, kind: 'boolean' },
+          { path: ['distill'], label: 'Distill', descriptions: { zh: '蒸馏（L1~L3 记忆整理）' }, kind: 'boolean' },
+          { path: ['recall'], label: 'Recall injection', descriptions: { zh: '召回注入' }, kind: 'boolean' },
+          {
+            path: ['reasoningEffort'],
+            label: 'Distill reasoning effort',
+            descriptions: { zh: '蒸馏思考档位' },
+            kind: 'select',
+            options: EFFORT_CHOICES.map((e) => ({ value: e, label: e === '' ? 'follow config' : e })),
+          },
+          {
+            path: ['distillProvider'],
+            label: 'Distill provider',
+            descriptions: { zh: '蒸馏模型供应商' },
+            kind: 'text',
+            hint: 'Empty = follow default model',
+            hintDescriptions: { zh: '留空跟随默认模型' },
+          },
+          {
+            path: ['distillModel'],
+            label: 'Distill model',
+            descriptions: { zh: '蒸馏模型' },
+            kind: 'text',
+            hint: 'Empty = follow default model',
+            hintDescriptions: { zh: '留空跟随默认模型' },
+          },
+          {
+            path: ['distillMaxInputChars'],
+            label: 'Distill input budget',
+            descriptions: { zh: '蒸馏输入预算（字符）' },
+            kind: 'number',
+            hint: '0 = default',
+            hintDescriptions: { zh: '0 = 默认' },
+          },
+        ],
+      });
+      logger.info('[memory] TUI 设置区块已注册（/settings · 分层蒸馏记忆）');
+      return dispose;
+    },
+    logger,
+  );
+}


### PR DESCRIPTION
## 概要

支持 DSH 宿主 0.1.2-alpha.1 ~ 0.1.2-rc.1；TUI 原生接缝兼容 dsh-tui 0.10.0-beta.x。

### 新增（CLI / TUI 终端形态支持）
- 宿主半边在 dsh-tui / headless 形态全链路工作（真机验证：挂载/召回/捕获/蒸馏）
- `/memory <auto|chat|work|off>` 会话档位切换（commands 为 base 服务全形态注册；TUI 无参弹托管选择面板）
- tuiStatus 状态行：当前会话档位常驻读数；live 设置变更即时刷新
- tuiSettingsSections 设置区块：dsh-memory 命名空间的声明式编辑面
- 三接缝软探测（ctx.get + internal/service 晚就绪补挂 + 下线摘挂接），web/headless 下 no-op
- README 补 dsh-TUI 官网链接（dshtui.com 市场收录归属门槛）

### 质量门禁
- typecheck 双检 / build / smoke 全绿（第 34 节新增 21 断言）
- 只读审查闭环：P0 agent.id 契约修复（真机复验切档日志 + 状态行目检）+ P2 + P3×5 全采纳